### PR TITLE
Update examples link in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ for event in events:
     toolbox.use(event)
 ```
 
-There are many more examples in the `examples` folder, viewable on github - [link](https://github.com/255BITS/ai-agent-toolbox/examples).
+There are many more examples in the `examples` folder, viewable on github - [link](https://github.com/255BITS/ai-agent-toolbox/tree/main/examples).
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- update the documentation home page to point the examples link at the repository folder

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_b_68d178ceeb20832890102c61c2e07e5f