### PR TITLE
Add LLM call step to quickstart guide

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -5,6 +5,7 @@
 1. Create a Toolbox:
 ```python
 from ai_agent_toolbox import Toolbox, XMLParser, XMLPromptFormatter
+from examples.util import anthropic_llm_call
 
 toolbox = Toolbox()
 parser = XMLParser()
@@ -36,7 +37,15 @@ system += formatter.usage_prompt(toolbox) # Add the instructions to use the tool
 prompt = "Think about something"
 ```
 
-4. Parse the response:
+4. Generate a response from your LLM:
+```python
+response = anthropic_llm_call(
+    prompt=prompt,
+    system_prompt=system,
+)
+```
+
+5. Parse the response:
 ```python
 events = parser.parse(response)
 
@@ -44,7 +53,7 @@ for event in events:
     toolbox.use(event)
 ```
 
-5. (optional) Use async streaming for calling tools ASAP:
+6. (optional) Use async streaming for calling tools ASAP:
 ```python
 # Stream the response
 async for chunk in anthropic_stream(system, prompt):


### PR DESCRIPTION
## Summary
- add an explicit step in the quickstart tutorial for calling an LLM to obtain `response`
- update the imports and numbering so the new snippet aligns with the surrounding setup

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_b_68d179035a80832883ebd9992b237f85