### PR TITLE
Update docs with canonical literal type names

### DIFF
--- a/docs/api-reference/core-concepts.md
+++ b/docs/api-reference/core-concepts.md
@@ -15,14 +15,14 @@ Tools themselves are simply functions. They can either by async or normal python
 
 ## Type Conversion System
 
-The Toolbox automatically converts arguments using these mappings:
+The Toolbox automatically converts arguments using these mappings. Supported literal types are `int`, `float`, `bool`, and `string`:
 
-| Input Value | Type      | Result          |
-|-------------|-----------|-----------------|
-| "42"        | integer   | 42 (int)        |
-| "3.14"      | number    | 3.14 (float)    |
-| "true"      | boolean   | True (bool)     |
-| "hello"     | string    | "hello" (str)   |
+| Input Value | Literal Type | Result          |
+|-------------|--------------|-----------------|
+| "42"        | int          | 42 (int)        |
+| "3.14"      | float        | 3.14 (float)    |
+| "true"      | bool         | True (bool)     |
+| "hello"     | string       | "hello" (str)   |
 
 ## Patterns
 

--- a/docs/api-reference/formatters.md
+++ b/docs/api-reference/formatters.md
@@ -27,7 +27,7 @@ Tool name: search
 Description: Web search tool
 Arguments:
   query (string): Search keywords
-  limit (integer): Maximum results to return
+  limit (int): Maximum results to return
 
 Example:
 <use_tool>


### PR DESCRIPTION
## Summary
- align the type conversion table with the canonical literal names
- update formatter documentation examples to use the same terminology

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_b_68d178e6f8b883289cc806014509322b