### PR TITLE
Fix installation docs repository URL

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -18,7 +18,7 @@ pip install ai-agent-toolbox
 For contributing or development:
 
 ```bash
-git clone https://github.com/yourusername/ai-agent-toolbox.git
+git clone https://github.com/255BITS/ai-agent-toolbox.git
 cd ai-agent-toolbox
 pip install -e ".[dev]"
 ```


### PR DESCRIPTION
## Summary
- update the development installation instructions to reference the official repository URL

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_b_68d178d2e4b0832890e041866869deb9