### PR TITLE
Fix duplicated code fence in toolbox docs

### DIFF
--- a/docs/api-reference/toolbox.md
+++ b/docs/api-reference/toolbox.md
@@ -30,7 +30,6 @@ When adding a tool, `args` can have any of the following type:
 ### Example Registration
 
 ```python
-```python
 def image_generate(prompt: str, style: str = "realistic"):
     """Generate image from text prompt"""
     pass


### PR DESCRIPTION
## Summary
- remove the duplicated python code fence around the Example Registration snippet so the code renders correctly

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_b_68d178dae6bc8328ab125192b8469153