### PR TITLE
Close FlatXML formatter code block

### DIFF
--- a/docs/api-reference/formatters.md
+++ b/docs/api-reference/formatters.md
@@ -76,7 +76,8 @@ class FlatXMLPromptFormatter(PromptFormatter):
     Methods:
         format_prompt(tools: Dict[str, Dict[str, str]]) -> str
             Returns a formatted XML string containing tool details.
-        
+
         usage_prompt(toolbox: Toolbox) -> str
             Generates the XML usage prompt based on the tools registered in a Toolbox.
     """
+```


### PR DESCRIPTION
## Summary
- close the FlatXMLPromptFormatter code fence in the formatter documentation to restore normal rendering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d17bf6b74c832889628ef5f8360c70