### PR TITLE
Align XML defaults with use_tool tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ from examples.util import anthropic_stream
 async def main():
     # Initialize components
     toolbox = Toolbox()
-    parser = XMLParser(tag="tool")
-    formatter = XMLPromptFormatter(tag="tool")
+    parser = XMLParser(tag="use_tool")
+    formatter = XMLPromptFormatter(tag="use_tool")
     
     # Register tools (add your actual tools here)
     toolbox.add_tool(

--- a/ai_agent_toolbox/formatters/xml/xml_prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/xml/xml_prompt_formatter.py
@@ -4,9 +4,10 @@ from ai_agent_toolbox.formatters.prompt_formatter import PromptFormatter
 class XMLPromptFormatter(PromptFormatter):
     """
     Formats tool usage prompts in XML format, compatible with XMLParser.
-    Assumes the use of <tool>, <name>, <argName> XML tags.
+    Assumes the use of the provided root tag (defaults to <use_tool>) along with
+    <name> and argument tags.
     """
-    def __init__(self, tag="tool"):
+    def __init__(self, tag="use_tool"):
         self.tag = tag
 
     def format_prompt(self, tools: Dict[str, Dict[str, str]]) -> str:

--- a/ai_agent_toolbox/parsers/xml/xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/xml_parser.py
@@ -16,7 +16,7 @@ class XMLParser(Parser):
     chunks to our ToolParser until it signals completion or we run out of data.
     """
 
-    def __init__(self, tag="tool"):
+    def __init__(self, tag="use_tool"):
         self.state = ParserState.OUTSIDE
         self.events: List[ParserEvent] = []
 

--- a/docs/api-reference/formatters.md
+++ b/docs/api-reference/formatters.md
@@ -6,18 +6,22 @@
 class XMLPromptFormatter:
     """
     Generates XML-structured prompts for tool documentation
-    
+
     Parameters:
         tag (str): Root XML tag (default: 'use_tool')
-    
+
     Methods:
         format_prompt(tools: Dict) -> str
             Create full prompt with XML tool descriptions
-            
+
         usage_prompt(toolbox: Toolbox) -> str
             Generate prompt section from registered tools
     """
 ```
+
+By instantiating `XMLPromptFormatter()` without arguments, the formatter will
+emit prompts that use the `<use_tool>` tag, matching the default for
+`XMLParser()`.
 
 ### Example Output
 

--- a/docs/api-reference/parsers.md
+++ b/docs/api-reference/parsers.md
@@ -10,7 +10,7 @@ Note that this is not a strict XML parser. The parser is very open with what it 
 class XMLParser:
     """
     Streaming XML parser for structured tool invocations
-    
+
     Parameters:
         tag (str): Root XML tag to parse (default: 'use_tool')
     
@@ -26,11 +26,15 @@ class XMLParser:
     """
 ```
 
+Creating an `XMLParser()` without arguments configures it to look for
+`<use_tool>` blocks. Provide a different `tag` value to parse alternative
+wrappers.
+
 ### Example Input
 ```python
     from ai_agent_toolbox import XMLParser
-    parser = XMLParser(tag="tool")
-    events = parser.parse("Searching... <tool><name>search</name><query>AI news</query></tool>")
+    parser = XMLParser()
+    events = parser.parse("Searching... <use_tool><name>search</name><query>AI news</query></use_tool>")
 ```
 ### Example Output
 


### PR DESCRIPTION
## Summary
- update XMLParser and XMLPromptFormatter defaults to use the `<use_tool>` tag
- clarify documentation and README examples so the documented default tag matches the implementation

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68d17bfea59c83289bf8b0fa1455ca65