### PR TITLE
Add golden streaming parser regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ next_response = llm_call(
 
 ```
 
+## Running Tests
+
+Streaming parsers in this project are validated against golden event traces so
+refactors keep their streaming semantics intact. Before opening a pull request,
+run the parser regression suite:
+
+```bash
+pytest tests/test_xml_parser.py tests/test_markdown_parser.py tests/test_flat_xml_parser.py
+```
+
+You can also execute the entire test suite with `pytest tests` to include any
+additional checks.
+
 ## Benefits
 
 | Feature/Capability          | AI Agent Toolbox ✅ | Naive Regex ❌ | Standard XML Parsers ❌ |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+import pathlib
+import sys
+from typing import Iterable, List
+
+import pytest
+
+# Ensure the repository root is importable when running tests without installing the package.
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ai_agent_toolbox.parser_event import ParserEvent
+
+
+@pytest.fixture
+def normalize_events():
+    """Normalize ParserEvent objects for deterministic comparison."""
+
+    def _normalize(events: Iterable[ParserEvent]):
+        id_map = {}
+        normalized: List[dict] = []
+        for event in events:
+            if event.id not in id_map:
+                id_map[event.id] = f"id{len(id_map)}"
+            entry = {
+                "type": event.type,
+                "mode": event.mode,
+                "id": id_map[event.id],
+                "is_tool_call": event.is_tool_call,
+            }
+            if event.content is not None:
+                entry["content"] = event.content
+            if event.tool is not None:
+                entry["tool"] = {
+                    "name": event.tool.name,
+                    "args": event.tool.args,
+                }
+            normalized.append(entry)
+        return normalized
+
+    return _normalize
+
+
+@pytest.fixture
+def stream_events(normalize_events):
+    """Stream parser chunks and return normalized events (including flush)."""
+
+    def _stream(parser, chunks: Iterable[str], *, flush: bool = True):
+        events: List[ParserEvent] = []
+        for chunk in chunks:
+            events.extend(parser.parse_chunk(chunk))
+        if flush:
+            events.extend(parser.flush())
+        return normalize_events(events)
+
+    return _stream

--- a/tests/test_flat_xml_parser.py
+++ b/tests/test_flat_xml_parser.py
@@ -1,0 +1,67 @@
+import pytest
+
+from ai_agent_toolbox.parsers.xml.flat_xml_parser import FlatXMLParser
+
+
+@pytest.fixture
+def flat_xml_event_goldens():
+    return {
+        "partial_tags_and_multiple_blocks": [
+            {"type": "text", "mode": "create", "id": "id0", "is_tool_call": False},
+            {"type": "text", "mode": "append", "id": "id0", "is_tool_call": False, "content": "Before "},
+            {"type": "text", "mode": "close", "id": "id0", "is_tool_call": False},
+            {"type": "tool", "mode": "create", "id": "id1", "is_tool_call": False},
+            {"type": "tool", "mode": "append", "id": "id1", "is_tool_call": False, "content": "One"},
+            {
+                "type": "tool",
+                "mode": "close",
+                "id": "id1",
+                "is_tool_call": True,
+                "content": "One",
+                "tool": {"name": "think", "args": {"content": "One"}},
+            },
+            {"type": "text", "mode": "create", "id": "id2", "is_tool_call": False},
+            {"type": "text", "mode": "append", "id": "id2", "is_tool_call": False, "content": " mid "},
+            {"type": "text", "mode": "close", "id": "id2", "is_tool_call": False},
+            {"type": "tool", "mode": "create", "id": "id3", "is_tool_call": False},
+            {"type": "tool", "mode": "append", "id": "id3", "is_tool_call": False, "content": "Go"},
+            {
+                "type": "tool",
+                "mode": "close",
+                "id": "id3",
+                "is_tool_call": True,
+                "content": "Go",
+                "tool": {"name": "action", "args": {"content": "Go"}},
+            },
+            {"type": "text", "mode": "create", "id": "id4", "is_tool_call": False},
+            {"type": "text", "mode": "append", "id": "id4", "is_tool_call": False, "content": " after"},
+            {"type": "text", "mode": "close", "id": "id4", "is_tool_call": False},
+        ],
+        "forced_close_on_flush": [
+            {"type": "tool", "mode": "create", "id": "id0", "is_tool_call": False},
+            {"type": "tool", "mode": "append", "id": "id0", "is_tool_call": False, "content": "value"},
+            {"type": "tool", "mode": "append", "id": "id0", "is_tool_call": False, "content": " continues"},
+            {
+                "type": "tool",
+                "mode": "close",
+                "id": "id0",
+                "is_tool_call": True,
+                "content": "value continues",
+                "tool": {"name": "think", "args": {"content": "value continues"}},
+            },
+        ],
+    }
+
+
+def test_flat_xml_parser_handles_partial_tags(flat_xml_event_goldens, stream_events):
+    parser = FlatXMLParser("think", "action")
+    chunks = ["Before <thin", "k>One</think> mid <", "action>Go</action> after"]
+    actual = stream_events(parser, chunks)
+    assert actual == flat_xml_event_goldens["partial_tags_and_multiple_blocks"]
+
+
+def test_flat_xml_parser_flushes_unclosed_tag(flat_xml_event_goldens, stream_events):
+    parser = FlatXMLParser("think")
+    chunks = ["<think>value", " continues"]
+    actual = stream_events(parser, chunks)
+    assert actual == flat_xml_event_goldens["forced_close_on_flush"]

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -1,0 +1,81 @@
+import pytest
+
+from ai_agent_toolbox.parsers.markdown.markdown_parser import MarkdownParser
+
+
+@pytest.fixture
+def markdown_event_goldens():
+    return {
+        "json_code_block": [
+            {"type": "text", "mode": "create", "id": "id0", "is_tool_call": False},
+            {"type": "text", "mode": "append", "id": "id0", "is_tool_call": False, "content": "Before "},
+            {"type": "text", "mode": "close", "id": "id0", "is_tool_call": False},
+            {"type": "tool", "mode": "create", "id": "id1", "is_tool_call": False},
+            {"type": "tool", "mode": "append", "id": "id1", "is_tool_call": False, "content": '{"key": 1'},
+            {"type": "tool", "mode": "append", "id": "id1", "is_tool_call": False, "content": "}\n"},
+            {
+                "type": "tool",
+                "mode": "close",
+                "id": "id1",
+                "is_tool_call": True,
+                "content": '{"key": 1}\n',
+                "tool": {"name": "json", "args": {"content": '{"key": 1}\n'}},
+            },
+            {"type": "text", "mode": "create", "id": "id2", "is_tool_call": False},
+            {"type": "text", "mode": "append", "id": "id2", "is_tool_call": False, "content": " After"},
+            {"type": "text", "mode": "close", "id": "id2", "is_tool_call": False},
+        ],
+        "partial_fence_then_close": [
+            {"type": "text", "mode": "create", "id": "id0", "is_tool_call": False},
+            {"type": "text", "mode": "append", "id": "id0", "is_tool_call": False, "content": "Intro "},
+            {"type": "text", "mode": "close", "id": "id0", "is_tool_call": False},
+            {"type": "tool", "mode": "create", "id": "id1", "is_tool_call": False},
+            {"type": "tool", "mode": "append", "id": "id1", "is_tool_call": False, "content": "code"},
+            {"type": "tool", "mode": "append", "id": "id1", "is_tool_call": False, "content": "\n"},
+            {
+                "type": "tool",
+                "mode": "close",
+                "id": "id1",
+                "is_tool_call": True,
+                "content": "code\n",
+                "tool": {"name": "python", "args": {"content": "code\n"}},
+            },
+            {"type": "text", "mode": "create", "id": "id2", "is_tool_call": False},
+            {"type": "text", "mode": "append", "id": "id2", "is_tool_call": False, "content": " trailing"},
+            {"type": "text", "mode": "close", "id": "id2", "is_tool_call": False},
+        ],
+        "forced_flush_completion": [
+            {"type": "tool", "mode": "create", "id": "id0", "is_tool_call": False},
+            {"type": "tool", "mode": "append", "id": "id0", "is_tool_call": False, "content": "line"},
+            {"type": "tool", "mode": "append", "id": "id0", "is_tool_call": False, "content": " one"},
+            {
+                "type": "tool",
+                "mode": "close",
+                "id": "id0",
+                "is_tool_call": True,
+                "content": "line one",
+                "tool": {"name": "python", "args": {"content": "line one"}},
+            },
+        ],
+    }
+
+
+def test_markdown_parser_streams_json_block(markdown_event_goldens, stream_events):
+    parser = MarkdownParser()
+    chunks = ["Before ```json\n{\"key\": 1", "}\n", "``` After"]
+    actual = stream_events(parser, chunks)
+    assert actual == markdown_event_goldens["json_code_block"]
+
+
+def test_markdown_parser_handles_partial_fence(markdown_event_goldens, stream_events):
+    parser = MarkdownParser()
+    chunks = ["Intro ``", "`python\ncode", "\n``` trailing"]
+    actual = stream_events(parser, chunks)
+    assert actual == markdown_event_goldens["partial_fence_then_close"]
+
+
+def test_markdown_parser_flushes_unclosed_block(markdown_event_goldens, stream_events):
+    parser = MarkdownParser()
+    chunks = ["```python\nline", " one"]
+    actual = stream_events(parser, chunks)
+    assert actual == markdown_event_goldens["forced_flush_completion"]

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -1,0 +1,101 @@
+import pytest
+
+from ai_agent_toolbox import XMLParser
+
+
+@pytest.fixture
+def xml_event_goldens():
+    return {
+        "partial_prefix_finalize": [
+            {"type": "text", "mode": "create", "id": "id0", "is_tool_call": False},
+            {"type": "text", "mode": "append", "id": "id0", "is_tool_call": False, "content": "Hello "},
+            {"type": "text", "mode": "close", "id": "id0", "is_tool_call": False},
+            {"type": "tool", "mode": "create", "id": "id1", "is_tool_call": False, "content": "calc"},
+            {"type": "tool", "mode": "append", "id": "id1", "is_tool_call": False, "content": "1,2"},
+            {"type": "tool", "mode": "append", "id": "id1", "is_tool_call": False, "content": "3"},
+            {
+                "type": "tool",
+                "mode": "close",
+                "id": "id1",
+                "is_tool_call": True,
+                "tool": {"name": "calc", "args": {"numbers": "1,23"}},
+            },
+        ],
+        "nested_tool_recovery": [
+            {"type": "tool", "mode": "create", "id": "id0", "is_tool_call": False, "content": "outer"},
+            {"type": "tool", "mode": "append", "id": "id0", "is_tool_call": False, "content": "prefix "},
+            {
+                "type": "tool",
+                "mode": "append",
+                "id": "id0",
+                "is_tool_call": False,
+                "content": "<name>inner</name>",
+            },
+            {"type": "tool", "mode": "append", "id": "id0", "is_tool_call": False, "content": "value"},
+            {
+                "type": "tool",
+                "mode": "close",
+                "id": "id0",
+                "is_tool_call": True,
+                "tool": {
+                    "name": "outer",
+                    "args": {"arg": "prefix value", "use_tool": "<name>inner</name>"},
+                },
+            },
+            {"type": "text", "mode": "create", "id": "id1", "is_tool_call": False},
+            {
+                "type": "text",
+                "mode": "append",
+                "id": "id1",
+                "is_tool_call": False,
+                "content": " suffix</arg></use_tool>",
+            },
+            {"type": "text", "mode": "close", "id": "id1", "is_tool_call": False},
+        ],
+        "invalid_tool_fallback": [
+            {"type": "text", "mode": "create", "id": "id0", "is_tool_call": False},
+            {"type": "text", "mode": "append", "id": "id0", "is_tool_call": False, "content": "pre "},
+            {"type": "text", "mode": "close", "id": "id0", "is_tool_call": False},
+            {
+                "type": "text",
+                "mode": "append",
+                "id": "id1",
+                "is_tool_call": False,
+                "content": " trailing text",
+            },
+            {"type": "text", "mode": "close", "id": "id1", "is_tool_call": False},
+        ],
+    }
+
+
+def test_xml_parser_partial_prefix_finalize(xml_event_goldens, stream_events):
+    """Chunks ending mid-tag trigger partial prefix buffering and flush finalizes the tool."""
+    parser = XMLParser(tag="use_tool")
+    chunks = ["Hello <use_to", "ol><name>calc</name><numbers>1,2", "3"]
+    actual = stream_events(parser, chunks)
+    assert actual == xml_event_goldens["partial_prefix_finalize"]
+
+
+def test_xml_parser_nested_tool_recovery(xml_event_goldens, stream_events):
+    """Nested tool markers inside arguments stay literal and stream resumes as text."""
+    parser = XMLParser(tag="use_tool")
+    chunks = [
+        "<use_tool><name>outer</name><arg>prefix ",
+        "<use_tool><name>inner</name>",
+        "<arg>value</arg></use_tool> suffix</arg></use_tool>",
+    ]
+    actual = stream_events(parser, chunks)
+    assert actual == xml_event_goldens["nested_tool_recovery"]
+
+
+def test_xml_parser_invalid_tool_promotes_text(xml_event_goldens, normalize_events):
+    """Malformed tool blocks without a <name> recover into plain text after flush."""
+    parser = XMLParser(tag="use_tool")
+    events = []
+    events.extend(parser.parse_chunk("pre <use_tool><invalid>"))
+    events.extend(parser.parse_chunk("value"))
+    events.extend(parser.flush())
+    events.extend(parser.parse_chunk(" trailing text"))
+    events.extend(parser.flush())
+    actual = normalize_events(events)
+    assert actual == xml_event_goldens["invalid_tool_fallback"]


### PR DESCRIPTION
## Summary
- add golden-event regression tests for the XML, Markdown, and Flat XML parsers
- normalize parser event IDs in tests so streaming chunks can be compared deterministically
- document how to run the parser regression suite in the README

## Testing
- pytest tests/test_xml_parser.py tests/test_markdown_parser.py tests/test_flat_xml_parser.py

------
https://chatgpt.com/codex/tasks/task_b_68d17e2fcb848328a2d6c85230003758