### PR TITLE
Add JSON parser and formatter with streaming tests

### DIFF
--- a/ai_agent_toolbox/__init__.py
+++ b/ai_agent_toolbox/__init__.py
@@ -2,12 +2,24 @@ from .toolbox import Toolbox
 from .parsers.xml.xml_parser import XMLParser
 from .parsers.xml.flat_xml_parser import FlatXMLParser
 from .parsers.markdown.markdown_parser import MarkdownParser
+from .parsers.json.json_parser import JSONParser
 from .formatters.xml.xml_prompt_formatter import XMLPromptFormatter
 from .formatters.xml.flat_xml_prompt_formatter import FlatXMLPromptFormatter
 from .formatters.markdown.markdown_prompt_formatter import MarkdownPromptFormatter
+from .formatters.json.json_prompt_formatter import JSONPromptFormatter
 from .parser_event import ParserEvent
 from .tool_response import ToolResponse
 
 __all__ = [
-    "Toolbox", "ParserEvent", "ToolResponse", "XMLParser", "FlatXMLParser", "XMLPromptFormatter", "FlatXMLPromptFormatter", "MarkdownParser", "MarkdownPromptFormatter"
+    "Toolbox",
+    "ParserEvent",
+    "ToolResponse",
+    "XMLParser",
+    "FlatXMLParser",
+    "JSONParser",
+    "XMLPromptFormatter",
+    "FlatXMLPromptFormatter",
+    "JSONPromptFormatter",
+    "MarkdownParser",
+    "MarkdownPromptFormatter",
 ]

--- a/ai_agent_toolbox/formatters/__init__.py
+++ b/ai_agent_toolbox/formatters/__init__.py
@@ -1,0 +1,4 @@
+from .prompt_formatter import PromptFormatter
+from .json.json_prompt_formatter import JSONPromptFormatter
+
+__all__ = ["PromptFormatter", "JSONPromptFormatter"]

--- a/ai_agent_toolbox/formatters/json/__init__.py
+++ b/ai_agent_toolbox/formatters/json/__init__.py
@@ -1,0 +1,3 @@
+from .json_prompt_formatter import JSONPromptFormatter
+
+__all__ = ["JSONPromptFormatter"]

--- a/ai_agent_toolbox/formatters/json/json_prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/json/json_prompt_formatter.py
@@ -1,0 +1,54 @@
+import json
+from typing import Any, Dict
+
+from ai_agent_toolbox.formatters.prompt_formatter import PromptFormatter
+
+
+class JSONPromptFormatter(PromptFormatter):
+    """Formats tool usage instructions for JSON-based tool calls."""
+
+    def format_prompt(self, tools: Dict[str, Dict[str, Any]]) -> str:
+        lines = [
+            "You can invoke the following tools by returning JSON objects with type \"tool_call\":",
+        ]
+
+        for tool_name, data in tools.items():
+            lines.extend([
+                f"Tool name: {tool_name}",
+                f"Description: {data.get('description', '')}",
+                "Arguments:",
+            ])
+
+            for arg_name, arg_schema in data.get("args", {}).items():
+                arg_type = arg_schema.get("type", "string")
+                arg_desc = arg_schema.get("description", "")
+                lines.append(f"  {arg_name} ({arg_type}): {arg_desc}")
+
+            lines.append("")
+
+        lines.append("Example tool call payloads:")
+
+        for tool_name, data in tools.items():
+            example_args = {}
+            for idx, (arg_name, arg_schema) in enumerate(data.get("args", {}).items(), start=1):
+                placeholder = f"value{idx}"
+                if arg_schema.get("type") in {"int", "integer"}:
+                    placeholder = idx
+                elif arg_schema.get("type") in {"number", "float"}:
+                    placeholder = float(idx)
+                example_args[arg_name] = placeholder
+
+            example_payload = {
+                "type": "tool_call",
+                "function": {
+                    "name": tool_name,
+                    "arguments": example_args,
+                },
+            }
+            lines.append(json.dumps(example_payload, indent=4))
+            lines.append("")
+
+        return "\n".join(lines).strip()
+
+    def usage_prompt(self, toolbox) -> str:
+        return self.format_prompt(toolbox._tools)

--- a/ai_agent_toolbox/parsers/__init__.py
+++ b/ai_agent_toolbox/parsers/__init__.py
@@ -1,1 +1,4 @@
 from .parser import Parser
+from .json.json_parser import JSONParser
+
+__all__ = ["Parser", "JSONParser"]

--- a/ai_agent_toolbox/parsers/json/__init__.py
+++ b/ai_agent_toolbox/parsers/json/__init__.py
@@ -1,0 +1,3 @@
+from .json_parser import JSONParser
+
+__all__ = ["JSONParser"]

--- a/ai_agent_toolbox/parsers/json/json_parser.py
+++ b/ai_agent_toolbox/parsers/json/json_parser.py
@@ -1,0 +1,479 @@
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parsers.parser import Parser
+
+
+@dataclass
+class ToolCallState:
+    """Tracks state for an in-flight JSON tool call."""
+
+    internal_id: str
+    name: Optional[str] = None
+    argument_buffer: str = ""
+    created: bool = False
+    closed: bool = False
+    keys: List[Tuple[str, Any]] = field(default_factory=list)
+
+
+class JSONParser(Parser):
+    """Parser that understands OpenAI/Anthropic style JSON tool call payloads."""
+
+    def __init__(self):
+        self.buffer: str = ""
+        self.events: List[ParserEvent] = []
+        self.current_text_id: Optional[str] = None
+
+        # Tool call tracking
+        self.tool_states: Dict[str, ToolCallState] = {}
+        self.tool_lookup: Dict[Tuple[str, Any], str] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def parse(self, text: str) -> List[ParserEvent]:
+        """Parse a complete JSON string and return all events."""
+        return self.parse_chunk(text) + self.flush()
+
+    def parse_chunk(self, chunk: str) -> List[ParserEvent]:
+        """Parse a chunk of JSON data (useful for streaming)."""
+        if not chunk:
+            return []
+
+        self.events = []
+        self.buffer += chunk
+        self._process_buffer(final=False)
+        events = self.events
+        self.events = []
+        return events
+
+    def flush(self) -> List[ParserEvent]:
+        """Finalize the parser state when no more chunks are expected."""
+        self.events = []
+        if self.buffer:
+            self._process_buffer(final=True)
+            self.buffer = ""
+
+        if self.current_text_id is not None:
+            self.events.append(
+                ParserEvent(
+                    type="text",
+                    mode="close",
+                    id=self.current_text_id,
+                    is_tool_call=False,
+                )
+            )
+            self.current_text_id = None
+
+        for state in list(self.tool_states.values()):
+            self._finalize_tool_state(state)
+
+        events = self.events
+        self.events = []
+        return events
+
+    # ------------------------------------------------------------------
+    # Buffer processing
+    # ------------------------------------------------------------------
+    def _process_buffer(self, final: bool) -> None:
+        while True:
+            result = self._extract_next_payload()
+            if result is None:
+                break
+
+            payload, consumed = result
+            if consumed == 0:
+                break
+
+            self.buffer = self.buffer[consumed:]
+
+            if payload is None:
+                continue
+
+            self._handle_payload(payload)
+
+        if final and self.buffer.strip():
+            try:
+                payload = json.loads(self.buffer)
+            except json.JSONDecodeError:
+                self.buffer = ""
+                return
+            self.buffer = ""
+            self._handle_payload(payload)
+
+    def _extract_next_payload(self) -> Optional[Tuple[Optional[Any], int]]:
+        if not self.buffer:
+            return None
+
+        idx = 0
+        length = len(self.buffer)
+
+        while idx < length and self.buffer[idx] in " \t\r\n":
+            idx += 1
+
+        if idx >= length:
+            return None
+
+        if self.buffer[idx] == ":":
+            newline = self.buffer.find("\n", idx)
+            if newline == -1:
+                return None
+            return None, newline + 1
+
+        if self.buffer.startswith("data:", idx):
+            idx += 5
+            while idx < length and self.buffer[idx] == " ":
+                idx += 1
+
+        if self.buffer.startswith("[DONE]", idx):
+            consumed = idx + len("[DONE]")
+            while consumed < length and self.buffer[consumed] in " \t\r\n":
+                consumed += 1
+            return None, consumed
+
+        decoder = json.JSONDecoder()
+        try:
+            payload, raw_end = decoder.raw_decode(self.buffer[idx:])
+        except json.JSONDecodeError:
+            return None
+
+        end_idx = idx + raw_end
+        consumed = end_idx
+        while consumed < length and self.buffer[consumed] in " \t\r\n":
+            consumed += 1
+
+        return payload, consumed
+
+    # ------------------------------------------------------------------
+    # Payload dispatch
+    # ------------------------------------------------------------------
+    def _handle_payload(self, payload: Any) -> None:
+        if payload is None:
+            return
+        if isinstance(payload, list):
+            for item in payload:
+                self._handle_payload(item)
+            return
+        if isinstance(payload, str):
+            self._stream_text(payload)
+            return
+        if isinstance(payload, dict):
+            self._handle_dict(payload)
+
+    def _handle_dict(self, data: Dict[str, Any]) -> None:
+        data_type = data.get("type")
+
+        if data_type == "content_block_start":
+            self._handle_anthropic_start(data)
+            return
+        if data_type == "content_block_delta":
+            self._handle_anthropic_delta(data)
+            return
+        if data_type == "content_block_stop":
+            self._handle_anthropic_stop(data)
+            return
+        if data_type in {"response.completed", "response.error"}:
+            self._finalize_all_tools()
+            return
+
+        if "choices" in data and isinstance(data["choices"], list):
+            for choice in data["choices"]:
+                self._handle_payload(choice)
+
+        if "message" in data:
+            self._handle_payload(data["message"])
+
+        if "delta" in data:
+            self._handle_payload(data["delta"])
+
+        if "output" in data and isinstance(data["output"], list):
+            for item in data["output"]:
+                self._handle_payload(item)
+
+        if "content" in data and isinstance(data["content"], list):
+            for item in data["content"]:
+                self._handle_payload(item)
+        elif isinstance(data.get("content"), str):
+            self._stream_text(data["content"])
+
+        if "tool_calls" in data and isinstance(data["tool_calls"], list):
+            for call in data["tool_calls"]:
+                self._handle_tool_call(call)
+
+        if "function_call" in data and isinstance(data["function_call"], dict):
+            payload = {"type": "function", "function": data["function_call"]}
+            if "id" in data:
+                payload["id"] = data["id"]
+            if "index" in data:
+                payload["index"] = data["index"]
+            self._handle_tool_call(payload)
+
+        if data.get("finish_reason") == "tool_calls":
+            self._finalize_all_tools()
+
+        if isinstance(data.get("delta"), str):
+            self._stream_text(data["delta"])
+
+        if isinstance(data.get("text"), str) and data_type not in {"tool_call", "function", "tool_use"}:
+            self._stream_text(data["text"])
+
+        if data_type in {"tool_call", "function", "tool_use"} or "function" in data or "arguments" in data:
+            self._handle_tool_call(data)
+
+    # ------------------------------------------------------------------
+    # Anthropic helpers
+    # ------------------------------------------------------------------
+    def _handle_anthropic_start(self, data: Dict[str, Any]) -> None:
+        block = data.get("content_block", {}) or {}
+        if block.get("type") != "tool_use":
+            # Non tool blocks can include text; handle via delta events.
+            return
+
+        payload = {
+            "type": "tool_use",
+            "id": block.get("id"),
+            "name": block.get("name"),
+        }
+        if "index" in data:
+            payload["index"] = data["index"]
+        if "input" in block:
+            payload["input"] = block["input"]
+
+        state = self._get_or_create_tool_state(payload)
+        if block.get("name"):
+            state.name = block["name"]
+        self._ensure_tool_created(state)
+
+        if isinstance(block.get("input"), dict) and block["input"]:
+            serialized = json.dumps(block["input"])
+            self._append_tool_arguments(state, serialized)
+            self._finalize_tool_state(state)
+
+    def _handle_anthropic_delta(self, data: Dict[str, Any]) -> None:
+        delta = data.get("delta", {}) or {}
+        delta_type = delta.get("type")
+
+        if delta_type == "input_json":
+            partial = delta.get("partial_json", "")
+            if partial:
+                state = self._get_or_create_tool_state({
+                    "type": "tool_use",
+                    "index": data.get("index"),
+                })
+                self._append_tool_arguments(state, partial)
+            return
+
+        text = delta.get("text")
+        if isinstance(text, str):
+            self._stream_text(text)
+
+    def _handle_anthropic_stop(self, data: Dict[str, Any]) -> None:
+        state = self._find_tool_state([
+            ("index", data.get("index")),
+        ])
+        if state:
+            self._finalize_tool_state(state)
+
+    # ------------------------------------------------------------------
+    # Tool state helpers
+    # ------------------------------------------------------------------
+    def _handle_tool_call(self, call: Dict[str, Any]) -> None:
+        if not isinstance(call, dict):
+            return
+
+        state = self._get_or_create_tool_state(call)
+
+        if not state.name:
+            name = call.get("name")
+            if not name:
+                function = call.get("function")
+                if isinstance(function, dict):
+                    name = function.get("name")
+            if name:
+                state.name = name
+        self._ensure_tool_created(state)
+
+        function = call.get("function")
+        if isinstance(function, dict):
+            arguments = function.get("arguments")
+            self._ingest_arguments(state, arguments)
+
+        if "arguments" in call:
+            self._ingest_arguments(state, call.get("arguments"))
+
+        if isinstance(call.get("input"), dict) and call.get("input"):
+            serialized = json.dumps(call["input"])
+            self._append_tool_arguments(state, serialized)
+
+        if call.get("status") in {"completed", "done", "finished"}:
+            self._finalize_tool_state(state)
+
+    def _ingest_arguments(self, state: ToolCallState, arguments: Any) -> None:
+        if arguments is None:
+            return
+        if isinstance(arguments, dict):
+            serialized = json.dumps(arguments)
+            self._append_tool_arguments(state, serialized)
+            self._finalize_tool_state(state)
+            return
+        if isinstance(arguments, str) and arguments:
+            self._append_tool_arguments(state, arguments)
+
+    def _append_tool_arguments(self, state: ToolCallState, text: str) -> None:
+        if not text:
+            return
+        self._ensure_tool_created(state)
+        state.argument_buffer += text
+        self.events.append(
+            ParserEvent(
+                type="tool",
+                mode="append",
+                id=state.internal_id,
+                is_tool_call=False,
+                content=text,
+            )
+        )
+
+    def _ensure_tool_created(self, state: ToolCallState) -> None:
+        if state.created:
+            return
+        self._close_text_block()
+        state.created = True
+        self.events.append(
+            ParserEvent(
+                type="tool",
+                mode="create",
+                id=state.internal_id,
+                is_tool_call=False,
+                content=state.name or "",
+            )
+        )
+
+    def _finalize_tool_state(self, state: ToolCallState) -> None:
+        if state.closed:
+            return
+        self._ensure_tool_created(state)
+        args: Dict[str, Any]
+        if state.argument_buffer.strip():
+            try:
+                parsed = json.loads(state.argument_buffer)
+            except json.JSONDecodeError:
+                args = {"arguments": state.argument_buffer}
+            else:
+                if isinstance(parsed, dict):
+                    args = parsed
+                else:
+                    args = {"value": parsed}
+        else:
+            args = {}
+
+        self.events.append(
+            ParserEvent(
+                type="tool",
+                mode="close",
+                id=state.internal_id,
+                is_tool_call=True,
+                tool=ToolUse(name=state.name or "", args=args),
+            )
+        )
+        state.closed = True
+        self._remove_tool_state(state)
+
+    def _finalize_all_tools(self) -> None:
+        for state in list(self.tool_states.values()):
+            self._finalize_tool_state(state)
+
+    def _remove_tool_state(self, state: ToolCallState) -> None:
+        if state.internal_id in self.tool_states:
+            del self.tool_states[state.internal_id]
+        for key in state.keys:
+            if self.tool_lookup.get(key) == state.internal_id:
+                del self.tool_lookup[key]
+
+    def _get_or_create_tool_state(self, data: Dict[str, Any]) -> ToolCallState:
+        candidates = self._collect_state_keys(data)
+        state = self._find_tool_state(candidates)
+        if state is None:
+            internal_id = str(uuid.uuid4())
+            state = ToolCallState(internal_id=internal_id)
+            self.tool_states[internal_id] = state
+        for key in candidates:
+            if key[1] is None:
+                continue
+            self.tool_lookup[key] = state.internal_id
+            if key not in state.keys:
+                state.keys.append(key)
+        return state
+
+    def _find_tool_state(self, candidates: List[Tuple[str, Any]]) -> Optional[ToolCallState]:
+        for key in candidates:
+            if key[1] is None:
+                continue
+            internal_id = self.tool_lookup.get(key)
+            if internal_id and internal_id in self.tool_states:
+                return self.tool_states[internal_id]
+        return None
+
+    def _collect_state_keys(self, data: Dict[str, Any]) -> List[Tuple[str, Any]]:
+        keys: List[Tuple[str, Any]] = []
+        for key_name in ("tool_call_id", "id", "index", "name"):
+            if key_name in data:
+                keys.append((key_name, data.get(key_name)))
+        function = data.get("function")
+        if isinstance(function, dict):
+            if "name" in function:
+                keys.append(("function_name", function.get("name")))
+            if "id" in function:
+                keys.append(("function_id", function.get("id")))
+            if "tool_call_id" in function:
+                keys.append(("function_tool_call_id", function.get("tool_call_id")))
+            if "index" in function:
+                keys.append(("function_index", function.get("index")))
+        return keys
+
+    # ------------------------------------------------------------------
+    # Text helpers
+    # ------------------------------------------------------------------
+    def _stream_text(self, text: str) -> None:
+        if not text:
+            return
+        self._open_text_block()
+        self.events.append(
+            ParserEvent(
+                type="text",
+                mode="append",
+                id=self.current_text_id,
+                is_tool_call=False,
+                content=text,
+            )
+        )
+
+    def _open_text_block(self) -> None:
+        if self.current_text_id is not None:
+            return
+        new_id = str(uuid.uuid4())
+        self.current_text_id = new_id
+        self.events.append(
+            ParserEvent(
+                type="text",
+                mode="create",
+                id=new_id,
+                is_tool_call=False,
+            )
+        )
+
+    def _close_text_block(self) -> None:
+        if self.current_text_id is None:
+            return
+        self.events.append(
+            ParserEvent(
+                type="text",
+                mode="close",
+                id=self.current_text_id,
+                is_tool_call=False,
+            )
+        )
+        self.current_text_id = None

--- a/docs/api-reference/formatters.md
+++ b/docs/api-reference/formatters.md
@@ -80,3 +80,20 @@ class FlatXMLPromptFormatter(PromptFormatter):
         usage_prompt(toolbox: Toolbox) -> str
             Generates the XML usage prompt based on the tools registered in a Toolbox.
     """
+```
+
+## JSONPromptFormatter
+
+```python
+class JSONPromptFormatter(PromptFormatter):
+    """
+    Formats tool usage prompts in JSON format with function-call examples.
+
+    Methods:
+        format_prompt(tools: Dict[str, Dict[str, Any]]) -> str
+            Render human readable documentation plus JSON snippets for each tool.
+
+        usage_prompt(toolbox: Toolbox) -> str
+            Convenience helper to format the current toolbox registry.
+    """
+```

--- a/docs/api-reference/parsers.md
+++ b/docs/api-reference/parsers.md
@@ -26,6 +26,34 @@ class XMLParser:
     """
 ```
 
+## JSONParser
+
+```python
+class JSONParser:
+    """
+    Streaming parser for JSON tool calls as produced by OpenAI, Anthropic, Groq, etc.
+
+    Methods:
+        parse(text: str) -> List[ParserEvent]
+            Parse a complete JSON payload.
+
+        parse_chunk(chunk: str) -> List[ParserEvent]
+            Feed streaming JSON or SSE chunks incrementally.
+
+        flush() -> List[ParserEvent]
+            Finalize parsing, closing open tool calls and text blocks.
+    """
+```
+
+### Example Usage
+
+```python
+from ai_agent_toolbox import JSONParser
+
+parser = JSONParser()
+events = parser.parse('{"type": "tool_call", "function": {"name": "search", "arguments": {"query": "AI"}}}')
+```
+
 ### Example Input
 ```python
     from ai_agent_toolbox import XMLParser

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,23 @@ for event in events:
 
 There are many more examples in the `examples` folder, viewable on github - [link](https://github.com/255BITS/ai-agent-toolbox/tree/main/examples).
 
+### JSON Based Tool Calls
+
+```python
+from ai_agent_toolbox import Toolbox, JSONParser, JSONPromptFormatter
+
+toolbox = Toolbox()
+parser = JSONParser()
+formatter = JSONPromptFormatter()
+
+system = "Respond with JSON tool calls when you need to act.\n"
+system += formatter.usage_prompt(toolbox)
+
+payload = llm_response_as_json(...)
+for event in parser.parse(payload):
+    toolbox.use(event)
+```
+
 ## Getting Started
 
 Check out our [Quick Start Guide](getting-started/quickstart.md) to begin using AI Agent Toolbox.

--- a/tests/formatters/json/test_json_prompt_formatter.py
+++ b/tests/formatters/json/test_json_prompt_formatter.py
@@ -1,0 +1,42 @@
+from ai_agent_toolbox.formatters.json.json_prompt_formatter import JSONPromptFormatter
+from ai_agent_toolbox.toolbox import Toolbox
+
+
+def test_json_prompt_formatter_outputs_example_payload():
+    formatter = JSONPromptFormatter()
+    prompt = formatter.format_prompt(
+        {
+            "search": {
+                "description": "Web search tool",
+                "args": {
+                    "query": {"type": "string", "description": "Search keywords"},
+                    "limit": {"type": "int", "description": "Max results"},
+                },
+            }
+        }
+    )
+
+    assert '"type": "tool_call"' in prompt
+    assert '"name": "search"' in prompt
+    assert '"query"' in prompt
+    assert '"limit"' in prompt
+
+
+def test_json_prompt_formatter_usage_prompt_from_toolbox():
+    toolbox = Toolbox()
+
+    def fetch(location: str) -> str:
+        return f"Weather for {location}"
+
+    toolbox.add_tool(
+        name="get_weather",
+        fn=fetch,
+        args={"location": {"type": "string", "description": "City to inspect"}},
+        description="Fetches the weather",
+    )
+
+    formatter = JSONPromptFormatter()
+    usage = formatter.usage_prompt(toolbox)
+
+    assert '"name": "get_weather"' in usage
+    assert '"location"' in usage

--- a/tests/parsers/json/test_json_parser.py
+++ b/tests/parsers/json/test_json_parser.py
@@ -1,0 +1,134 @@
+import json
+
+from ai_agent_toolbox.parsers.json.json_parser import JSONParser
+
+
+def collect(events, *, type_, mode):
+    return [event for event in events if event.type == type_ and event.mode == mode]
+
+
+def test_json_parser_one_shot_openai_payload():
+    parser = JSONParser()
+    payload = json.dumps(
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Thinking..."},
+                {
+                    "type": "tool_call",
+                    "id": "call_123",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": {"location": "Paris", "unit": "celsius"},
+                    },
+                },
+            ],
+        }
+    )
+
+    events = parser.parse(payload)
+
+    text_content = "".join(event.content for event in collect(events, type_="text", mode="append"))
+    assert text_content == "Thinking..."
+
+    tool_creates = collect(events, type_="tool", mode="create")
+    assert tool_creates and tool_creates[0].content == "get_weather"
+
+    tool_closes = collect(events, type_="tool", mode="close")
+    assert len(tool_closes) == 1
+    close_event = tool_closes[0]
+    assert close_event.is_tool_call
+    assert close_event.tool.name == "get_weather"
+    assert close_event.tool.args == {"location": "Paris", "unit": "celsius"}
+
+
+def test_json_parser_streaming_openai_tool_call():
+    parser = JSONParser()
+    chunks = [
+        'data: {"type":"response.delta","delta":{"content":[{"type":"output_text","text":"Working on it"}]}}\n\n',
+        'data: {"type":"response.delta","delta":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather"}}]}}\n\n',
+        'data: {"type":"response.delta","delta":{"tool_calls":[{"id":"call_1","type":"function","function":{"arguments":"{\\"location\\":\\"Boston\\""}}]}}\n\n',
+        'data: {"type":"response.delta","delta":{"tool_calls":[{"id":"call_1","type":"function","function":{"arguments":"}"}}]}}\n\n',
+        'data: {"type":"response.completed"}\n\n',
+    ]
+
+    all_events = []
+    for chunk in chunks:
+        all_events.extend(parser.parse_chunk(chunk))
+
+    # flush should not emit duplicates but should be safe
+    all_events.extend(parser.flush())
+
+    text_chunks = collect(all_events, type_="text", mode="append")
+    assert "".join(event.content for event in text_chunks) == "Working on it"
+
+    tool_creates = collect(all_events, type_="tool", mode="create")
+    assert tool_creates and tool_creates[0].content == "get_weather"
+
+    tool_appends = collect(all_events, type_="tool", mode="append")
+    assert [event.content for event in tool_appends] == ['{"location":"Boston"', '}']
+
+    tool_closes = collect(all_events, type_="tool", mode="close")
+    assert len(tool_closes) == 1
+    close_event = tool_closes[0]
+    assert close_event.tool.args == {"location": "Boston"}
+
+
+def test_json_parser_streaming_anthropic_tool_use():
+    parser = JSONParser()
+    chunks = [
+        json.dumps(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "get_weather",
+                    "input": {},
+                },
+            }
+        )
+        + "\n",
+        json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "input_json",
+                    "partial_json": '{"location":"Rome"',
+                },
+            }
+        )
+        + "\n",
+        json.dumps(
+            {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {
+                    "type": "input_json",
+                    "partial_json": "}",
+                },
+            }
+        )
+        + "\n",
+        json.dumps({"type": "content_block_stop", "index": 0}) + "\n",
+    ]
+
+    all_events = []
+    for chunk in chunks:
+        all_events.extend(parser.parse_chunk(chunk))
+
+    all_events.extend(parser.flush())
+
+    tool_creates = collect(all_events, type_="tool", mode="create")
+    assert tool_creates and tool_creates[0].content == "get_weather"
+
+    tool_appends = collect(all_events, type_="tool", mode="append")
+    assert tool_appends[0].content == '{"location":"Rome"'
+    assert tool_appends[1].content == "}"
+
+    tool_closes = collect(all_events, type_="tool", mode="close")
+    assert len(tool_closes) == 1
+    close_event = tool_closes[0]
+    assert close_event.tool.args == {"location": "Rome"}


### PR DESCRIPTION
## Summary
- add a JSON streaming parser that reconstructs OpenAI and Anthropic style tool calls
- introduce a JSON prompt formatter and expose both classes through public exports and docs
- document the new feature and cover it with regression tests for one-shot and streaming payloads

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_b_68d17e1ca748832897403dbf649f87e2