### PR TITLE
Improve tool argument validation and error reporting

### DIFF
--- a/ai_agent_toolbox/tool_response.py
+++ b/ai_agent_toolbox/tool_response.py
@@ -2,7 +2,9 @@ from dataclasses import dataclass
 from typing import Any, Optional
 from .parser_event import ToolUse
 
+
 @dataclass
 class ToolResponse:
     tool: ToolUse
     result: Optional[Any] = None
+    error: Optional[Any] = None

--- a/ai_agent_toolbox/toolbox.py
+++ b/ai_agent_toolbox/toolbox.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Tuple
 from .parser_event import ParserEvent, ToolUse
 from .tool_response import ToolResponse
 import inspect
@@ -25,9 +25,15 @@ class Toolbox:
 
     def use(self, event: ParserEvent) -> Optional[ToolResponse]:
         """For sync tool execution only"""
-        tool_data = self._get_tool_data(event)
-        if not tool_data:
+        tool_data, error = self._get_tool_data(event)
+        if tool_data is None and error is None:
             return None
+
+        if error:
+            return ToolResponse(
+                tool=event.tool,
+                error=error
+            )
 
         if tool_data["is_async"]:
             raise RuntimeError(f"Async tool {event.tool.name} called with sync use(). Call use_async() instead.")
@@ -40,9 +46,16 @@ class Toolbox:
 
     async def use_async(self, event: ParserEvent) -> Optional[ToolResponse]:
         """For both sync and async tools"""
-        tool_data = self._get_tool_data(event)
-        if not tool_data:
+        tool_data, error = self._get_tool_data(event)
+        if tool_data is None and error is None:
             return None
+
+        if error:
+            return ToolResponse(
+                tool=event.tool,
+                error=error
+            )
+
         if tool_data["is_async"]:
             tool_result = await tool_data["fn"](**tool_data["processed_args"])
         else:
@@ -52,37 +65,108 @@ class Toolbox:
             result=tool_result
         )
 
-    def _get_tool_data(self, event: ParserEvent) -> Optional[Dict]:
+    def _get_tool_data(self, event: ParserEvent) -> Tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
         """Shared validation and argument processing"""
         if not event.is_tool_call or not event.tool:
-            return None
+            return None, None
 
         tool_name = event.tool.name
         if tool_name not in self._tools:
-            return None
+            return None, {
+                "type": "unknown_tool",
+                "message": f"Tool '{tool_name}' is not registered."
+            }
 
-        tool_data = {**self._tools[tool_name]}  # Shallow copy
-        processed_args = {}
-        
-        for arg_name, arg_schema in tool_data["args"].items():
-            if arg_name not in event.tool.args:
-                print("Could not find argument", arg_name)
+        tool_def = self._tools[tool_name]
+        tool_data = {**tool_def}  # Shallow copy
+        processed_args: Dict[str, Any] = {}
+        validation_errors = []
+        errored_fields = set()
+        provided_args = event.tool.args or {}
+
+        for arg_name, arg_schema in tool_def.get("args", {}).items():
+            schema = arg_schema or {}
+            required = schema.get("required", True)
+            arg_type = schema.get("type", "string")
+            has_value = arg_name in provided_args and provided_args[arg_name] is not None
+
+            if not has_value:
+                if "default" in schema:
+                    default_value = schema["default"]
+                    try:
+                        processed_args[arg_name] = self._convert_arg(default_value, arg_type)
+                    except (ValueError, TypeError) as exc:
+                        validation_errors.append({
+                            "field": arg_name,
+                            "type": "invalid_default",
+                            "message": f"Default value for '{arg_name}' is not valid for type '{arg_type}'.",
+                            "value": default_value,
+                            "details": str(exc)
+                        })
+                        errored_fields.add(arg_name)
+                elif required:
+                    validation_errors.append({
+                        "field": arg_name,
+                        "type": "missing",
+                        "message": f"Missing required argument '{arg_name}'."
+                    })
+                    errored_fields.add(arg_name)
                 continue
-                
-            raw_value = event.tool.args[arg_name]
-            arg_type = arg_schema.get("type", "string")
-            processed_args[arg_name] = self._convert_arg(raw_value, arg_type)
-        
+
+            raw_value = provided_args[arg_name]
+            try:
+                processed_args[arg_name] = self._convert_arg(raw_value, arg_type)
+            except (ValueError, TypeError) as exc:
+                validation_errors.append({
+                    "field": arg_name,
+                    "type": "invalid",
+                    "message": f"Invalid value for '{arg_name}' with type '{arg_type}'.",
+                    "value": raw_value,
+                    "details": str(exc)
+                })
+                errored_fields.add(arg_name)
+
+        for arg_name, raw_value in provided_args.items():
+            if arg_name in errored_fields:
+                continue
+            if arg_name not in processed_args:
+                processed_args[arg_name] = raw_value
+
         tool_data["processed_args"] = processed_args
-        return tool_data
+
+        if validation_errors:
+            return tool_data, {
+                "type": "validation_error",
+                "message": "Argument validation failed.",
+                "errors": validation_errors
+            }
+
+        return tool_data, None
 
     @staticmethod
-    def _convert_arg(value: str, arg_type: str) -> Any:
-        """Converts string arguments to specified types"""
+    def _convert_arg(value: Any, arg_type: str) -> Any:
+        """Converts arguments to specified types"""
         if arg_type == "int":
+            if isinstance(value, int):
+                return value
             return int(value)
         if arg_type == "float":
+            if isinstance(value, float):
+                return value
+            if isinstance(value, int):
+                return float(value)
             return float(value)
         if arg_type == "bool":
-            return value.lower() in ("true", "1", "yes")
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                if normalized in ("true", "1", "yes", "y", "on"):
+                    return True
+                if normalized in ("false", "0", "no", "n", "off"):
+                    return False
+                raise ValueError(f"Cannot convert '{value}' to bool")
+            if isinstance(value, (int, float)):
+                return bool(value)
+            raise TypeError(f"Cannot convert type {type(value).__name__} to bool")
         return value  # Default to string

--- a/docs/api-reference/tool-response.md
+++ b/docs/api-reference/tool-response.md
@@ -1,6 +1,6 @@
 # Tool Response
 
-`ToolResponse` objects encapsulate the successful outcome of tool executions and contextual metadata.
+`ToolResponse` objects encapsulate both successful outcomes and structured failures from tool executions alongside contextual metadata.
 
 ## Structure
 
@@ -9,6 +9,7 @@
 class ToolResponse:
     tool: ToolUse         # Tool invocation details (name and arguments)
     result: Optional[Any] # Return value from tool execution
+    error: Optional[Any]  # Structured error payload when execution is skipped
 ```
 
 ## Key Features
@@ -19,14 +20,16 @@ class ToolResponse:
 
 ## Example Usage
 ```python
-try:
-    response = toolbox.use(event)
-except Exception as exc:
-    handle_tool_failure(exc)
-else:
+response = toolbox.use(event)
+if response and response.error:
+    # Example: validation errors include the failing field and reason
+    print("Tool call rejected:", response.error)
+elif response:
     print(f"{response.tool.name} result: {response.result}")
 ```
 
 ## Error Handling
 
 `Toolbox.use()` and `Toolbox.use_async()` do not wrap tool exceptions. If a registered tool raises an error, the exception propagates to the caller and no `ToolResponse` is produced. Use standard Python error handling (e.g., `try`/`except`) around tool invocation when you need to intercept or recover from failures.
+
+Schema validation issues and missing tools do not raise; instead the toolbox returns a `ToolResponse` whose `error` field contains a machine-readable payload (e.g., `{"type": "validation_error", ...}`). Forward this back to the LLM to request corrected arguments.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -14,8 +14,10 @@ formatter = XMLPromptFormatter()
 
 2. Define and Add Tools:
 ```python
-def thinking(thoughts=""):
-    print(f"Thinking: {thoughts}")
+def thinking(thoughts: str, tone: str = "curious"):
+    message = f"Thinking ({tone}): {thoughts}"
+    print(message)
+    return message
 
 toolbox.add_tool(
     name="thinking",
@@ -23,8 +25,15 @@ toolbox.add_tool(
     args={
         "thoughts": {
             "type": "string",
-            "description": "Thoughts to process"
-        }
+            "description": "Thoughts to process",
+            "required": True,
+        },
+        "tone": {
+            "type": "string",
+            "description": "Optional vibe for the thought",
+            "required": False,
+            "default": "curious",
+        },
     },
     description="For thinking out loud"
 )
@@ -50,7 +59,11 @@ response = anthropic_llm_call(
 events = parser.parse(response)
 
 for event in events:
-    toolbox.use(event)
+    response = toolbox.use(event)
+    if response and response.error:
+        print("Tool validation error:", response.error)
+    elif response:
+        print(f"{response.tool.name} result:", response.result)
 ```
 
 6. (optional) Use async streaming for calling tools ASAP:

--- a/examples/00.simple.py
+++ b/examples/00.simple.py
@@ -7,8 +7,10 @@ parser = XMLParser(tag="use_tool")
 formatter = XMLPromptFormatter(tag="use_tool")
 
 # Add tools to your toolbox
-def thinking(thoughts=""):
-    print("I'm thinking:", thoughts)
+def thinking(thoughts: str, tone: str = "curious"):
+    message = f"I'm thinking ({tone}): {thoughts}"
+    print(message)
+    return message
 
 toolbox.add_tool(
     name="thinking",
@@ -16,8 +18,15 @@ toolbox.add_tool(
     args={
         "thoughts": {
             "type": "string",
-            "description": "Anything you want to think about"
-        }
+            "description": "Anything you want to think about",
+            "required": True,
+        },
+        "tone": {
+            "type": "string",
+            "description": "Optional vibe for the thoughts",
+            "required": False,
+            "default": "curious",
+        },
     },
     description="For thinking out loud"
 )
@@ -32,4 +41,8 @@ response = anthropic_llm_call(system_prompt=system, prompt=prompt)
 events = parser.parse(response)
 
 for event in events:
-    toolbox.use(event)
+    response = toolbox.use(event)
+    if response and response.error:
+        print("Tool validation error:", response.error)
+    elif response:
+        print(f"{response.tool.name} result:", response.result)

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from unittest.mock import Mock
 
@@ -28,6 +29,7 @@ def test_use_tool_happy_path():
     result = toolbox.use(event)
     mock_fn.assert_called_once_with(thoughts="test thoughts")
     assert result.result == "Called successfully"
+    assert result.error is None
 
 
 def test_use_tool_missing_tool():
@@ -45,7 +47,12 @@ def test_use_tool_missing_tool():
         is_tool_call=True
     )
     result = toolbox.use(event)
-    assert result is None
+    assert result is not None
+    assert result.result is None
+    assert result.error == {
+        "type": "unknown_tool",
+        "message": "Tool 'missing_tool' is not registered."
+    }
 
 
 def test_use_event_not_a_tool_call():
@@ -131,3 +138,206 @@ def test_type_conversion():
         "float_arg": 3.14,
         "bool_arg": True
     }
+    assert response.error is None
+
+
+def test_sync_tool_validation_success():
+    toolbox = Toolbox()
+
+    def sample_tool(topic: str, max_results: int, tone: str):
+        return {
+            "topic": topic,
+            "max_results": max_results,
+            "tone": tone,
+        }
+
+    toolbox.add_tool(
+        name="research",
+        fn=sample_tool,
+        args={
+            "topic": {"type": "string"},
+            "max_results": {"type": "int", "required": False},
+            "tone": {"type": "string", "required": False, "default": "neutral"},
+        }
+    )
+
+    event = ParserEvent(
+        type="tool",
+        mode="close",
+        id="event-id",
+        tool=ToolUse(
+            name="research",
+            args={"topic": "LLMs", "max_results": "5", "tone": "curious"}
+        ),
+        is_tool_call=True,
+    )
+
+    response = toolbox.use(event)
+    assert response.error is None
+    assert response.result == {
+        "topic": "LLMs",
+        "max_results": 5,
+        "tone": "curious",
+    }
+
+
+def test_sync_tool_missing_required_argument():
+    toolbox = Toolbox()
+    called = {"called": False}
+
+    def sample_tool(topic: str):
+        called["called"] = True
+        return topic
+
+    toolbox.add_tool(
+        name="research",
+        fn=sample_tool,
+        args={"topic": {"type": "string"}},
+    )
+
+    event = ParserEvent(
+        type="tool",
+        mode="close",
+        id="event-id",
+        tool=ToolUse(name="research", args={}),
+        is_tool_call=True,
+    )
+
+    response = toolbox.use(event)
+    assert not called["called"]
+    assert response.result is None
+    assert response.error is not None
+    assert response.error["type"] == "validation_error"
+    assert response.error["message"] == "Argument validation failed."
+    assert response.error["errors"][0]["field"] == "topic"
+    assert response.error["errors"][0]["type"] == "missing"
+
+
+def test_sync_tool_optional_argument_default():
+    toolbox = Toolbox()
+    recorded = {}
+
+    def sample_tool(topic: str, max_results: int = 3):
+        recorded["args"] = {"topic": topic, "max_results": max_results}
+        return max_results
+
+    toolbox.add_tool(
+        name="research",
+        fn=sample_tool,
+        args={
+            "topic": {"type": "string"},
+            "max_results": {"type": "int", "required": False, "default": "7"},
+        }
+    )
+
+    event = ParserEvent(
+        type="tool",
+        mode="close",
+        id="event-id",
+        tool=ToolUse(name="research", args={"topic": "LLMs"}),
+        is_tool_call=True,
+    )
+
+    response = toolbox.use(event)
+    assert response.error is None
+    assert response.result == 7
+    assert recorded["args"] == {"topic": "LLMs", "max_results": 7}
+
+
+def test_async_tool_validation_success():
+    toolbox = Toolbox()
+
+    async def sample_tool(topic: str, max_results: int):
+        return {
+            "topic": topic,
+            "max_results": max_results,
+        }
+
+    toolbox.add_tool(
+        name="research_async",
+        fn=sample_tool,
+        args={
+            "topic": {"type": "string"},
+            "max_results": {"type": "int"},
+        }
+    )
+
+    async def run():
+        event = ParserEvent(
+            type="tool",
+            mode="close",
+            id="event-id",
+            tool=ToolUse(name="research_async", args={"topic": "LLMs", "max_results": "2"}),
+            is_tool_call=True,
+        )
+        return await toolbox.use_async(event)
+
+    response = asyncio.run(run())
+    assert response.error is None
+    assert response.result == {"topic": "LLMs", "max_results": 2}
+
+
+def test_async_tool_missing_required_argument():
+    toolbox = Toolbox()
+    called = {"called": False}
+
+    async def sample_tool(topic: str):
+        called["called"] = True
+        return topic
+
+    toolbox.add_tool(
+        name="research_async",
+        fn=sample_tool,
+        args={"topic": {"type": "string"}},
+    )
+
+    async def run():
+        event = ParserEvent(
+            type="tool",
+            mode="close",
+            id="event-id",
+            tool=ToolUse(name="research_async", args={}),
+            is_tool_call=True,
+        )
+        return await toolbox.use_async(event)
+
+    response = asyncio.run(run())
+    assert not called["called"]
+    assert response.result is None
+    assert response.error is not None
+    assert response.error["type"] == "validation_error"
+    assert response.error["errors"][0]["field"] == "topic"
+    assert response.error["errors"][0]["type"] == "missing"
+
+
+def test_async_tool_optional_argument_default():
+    toolbox = Toolbox()
+    recorded = {}
+
+    async def sample_tool(topic: str, max_results: int = 3):
+        recorded["args"] = {"topic": topic, "max_results": max_results}
+        return max_results
+
+    toolbox.add_tool(
+        name="research_async",
+        fn=sample_tool,
+        args={
+            "topic": {"type": "string"},
+            "max_results": {"type": "int", "required": False, "default": "4"},
+        }
+    )
+
+    async def run():
+        event = ParserEvent(
+            type="tool",
+            mode="close",
+            id="event-id",
+            tool=ToolUse(name="research_async", args={"topic": "LLMs"}),
+            is_tool_call=True,
+        )
+        return await toolbox.use_async(event)
+
+    response = asyncio.run(run())
+    assert response.error is None
+    assert response.result == 4
+    assert recorded["args"] == {"topic": "LLMs", "max_results": 4}


### PR DESCRIPTION
## Summary
- enforce required/optional tool argument handling with defaults and structured validation errors
- add ToolResponse.error plus docs/examples explaining schema usage and runtime feedback
- expand sync and async toolbox tests to cover happy path, missing required args, and optional defaults

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_b_68d17e1f91f88328918851f931b93f20