### PR TITLE
Refine parser base class and reuse implementation

### DIFF
--- a/ai_agent_toolbox/parsers/json/json_parser.py
+++ b/ai_agent_toolbox/parsers/json/json_parser.py
@@ -34,10 +34,6 @@ class JSONParser(Parser):
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
-    def parse(self, text: str) -> List[ParserEvent]:
-        """Parse a complete JSON string and return all events."""
-        return self.parse_chunk(text) + self.flush()
-
     def parse_chunk(self, chunk: str) -> List[ParserEvent]:
         """Parse a chunk of JSON data (useful for streaming)."""
         if not chunk:

--- a/ai_agent_toolbox/parsers/markdown/markdown_parser.py
+++ b/ai_agent_toolbox/parsers/markdown/markdown_parser.py
@@ -24,13 +24,6 @@ class MarkdownParser(Parser):
         self.current_tool_name = None  # from language identifier; default "code"
         self.tool_content_buffer = []
 
-    def parse(self, text: str):
-        """Convenience method for one-shot parsing."""
-        events = []
-        events.extend(self.parse_chunk(text))
-        events.extend(self.flush())
-        return events
-
     def parse_chunk(self, chunk: str):
         """Process an incoming chunk of text and emit ParserEvent objects."""
         events = []

--- a/ai_agent_toolbox/parsers/parser.py
+++ b/ai_agent_toolbox/parsers/parser.py
@@ -3,10 +3,10 @@ from ai_agent_toolbox.parser_event import ParserEvent
 
 class Parser:
     def parse(self, text: str) -> List[ParserEvent]:
-        pass
+        return self.parse_chunk(text) + self.flush()
 
     def parse_chunk(self, chunk: str) -> List[ParserEvent]:
-        pass
+        raise NotImplementedError
 
     def flush(self) -> List[ParserEvent]:
-        pass
+        raise NotImplementedError

--- a/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
@@ -39,16 +39,6 @@ class FlatXMLParser(Parser):
         self._tool_id = None
         self._tool_content_buffer = []
 
-    def parse(self, text: str):
-        """
-        Convenience method for parsing all text at once.
-        Returns all events in a single list (non-streaming usage).
-        """
-        events = []
-        events.extend(self.parse_chunk(text))
-        events.extend(self.flush())
-        return events
-
     def parse_chunk(self, chunk: str):
         """
         Consume `chunk` in a streaming-friendly way.

--- a/ai_agent_toolbox/parsers/xml/xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/xml_parser.py
@@ -28,11 +28,6 @@ class XMLParser(Parser):
         self.tag = tag
         self.start_tag = f"<{tag}>"
 
-    def parse(self, text: str) -> List[ParserEvent]:
-        # Parse in streaming style, then flush.
-        # Summarize all events.
-        return self.parse_chunk(text) + self.flush()
-
     def parse_chunk(self, chunk: str) -> List[ParserEvent]:
         self.events = []
 


### PR DESCRIPTION
## Summary
- implement `Parser.parse` so the base class combines `parse_chunk` and `flush`, and mark the chunk/flush hooks as abstract via `NotImplementedError`
- remove redundant `parse` overrides from the JSON, Markdown, XML, and flat XML parsers so they inherit the shared behavior

## Testing
- pytest tests/parsers

------
https://chatgpt.com/codex/tasks/task_b_68d18990a9f883289126513d7bd6c730