### PR TITLE
Clean up XML parser tests

### DIFF
--- a/tests/parsers/xml/test_flat_xml_parser.py
+++ b/tests/parsers/xml/test_flat_xml_parser.py
@@ -1,8 +1,6 @@
 import pytest
 from ai_agent_toolbox.parsers.xml.flat_xml_parser import FlatXMLParser
 from ai_agent_toolbox.parser_event import ParserEvent
-import re
-from pprint import pprint
 
 @pytest.fixture
 def parser():
@@ -175,7 +173,6 @@ def test_interleaved_text(parser):
 def test_unclosed_tag(parser):
     text = "<think>Partially closed"
     events = list(parser.parse(text))
-    pprint(events)
     # We get 3 events for the recognized tag: create, append, close
     assert len(events) == 3
 

--- a/tests/parsers/xml/test_xml_parser.py
+++ b/tests/parsers/xml/test_xml_parser.py
@@ -1,17 +1,14 @@
 import pytest
 from ai_agent_toolbox import XMLParser
-from pprint import pprint
 
 @pytest.fixture
 def parser():
     return XMLParser(tag="use_tool")
 
-def assert_text_create(event, expected_id_pattern=None):
+def assert_text_create(event):
     assert event.type == "text"
     assert event.mode == "create"
     assert event.id is not None
-    if expected_id_pattern:
-        assert re.match(expected_id_pattern, event.id)
 
 def assert_text_append(event, text_id, content):
     assert event.type == "text"
@@ -267,7 +264,6 @@ def test_complex_nested_content(parser):
     assert events[2].mode == "append"
     
     # Tool closure
-    pprint(events)
     assert_tool_close(events[3], tool_id)
 
 def test_invalid_tool_argument(parser):


### PR DESCRIPTION
## Summary
- remove debug-only imports and print statements from the XML parser tests
- simplify the XML parser test helper so it no longer references an undefined regular expression helper

## Testing
- pytest tests/parsers/xml/test_flat_xml_parser.py tests/parsers/xml/test_xml_parser.py

------
https://chatgpt.com/codex/tasks/task_b_68d189c5a30c8328a0ffbe9d9b731ff3