### PR TITLE
Ensure XML parser flush emits trailing text create

### DIFF
--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -56,6 +56,7 @@ def xml_event_goldens():
             {"type": "text", "mode": "create", "id": "id0", "is_tool_call": False},
             {"type": "text", "mode": "append", "id": "id0", "is_tool_call": False, "content": "pre "},
             {"type": "text", "mode": "close", "id": "id0", "is_tool_call": False},
+            {"type": "text", "mode": "create", "id": "id1", "is_tool_call": False},
             {
                 "type": "text",
                 "mode": "append",


### PR DESCRIPTION
## Summary
- ensure `XMLParser.flush` routes internal helpers through the flush event list so trailing text creates are emitted
- adjust the invalid tool fallback golden to expect the new text create event before the trailing append

## Testing
- `pytest tests/test_xml_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68d189c20cc483288cd8022ede86cd08