### PR TITLE
Refactor parser prefix preservation helper

### DIFF
--- a/ai_agent_toolbox/parsers/markdown/markdown_parser.py
+++ b/ai_agent_toolbox/parsers/markdown/markdown_parser.py
@@ -1,6 +1,7 @@
 import uuid
-from ai_agent_toolbox.parsers.parser import Parser
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parsers.parser import Parser
+from ai_agent_toolbox.parsers.utils import longest_prefix_at_end
 
 class MarkdownParser(Parser):
     """
@@ -97,7 +98,7 @@ class MarkdownParser(Parser):
         if idx == -1:
             # No complete opening fence found. Check if the end of the buffer
             # is a partial fence.
-            partial_len = self._longest_prefix_at_end(self.buffer, self.OPEN_FENCE)
+            partial_len = longest_prefix_at_end(self.buffer, self.OPEN_FENCE)
             if partial_len:
                 if len(self.buffer) > partial_len:
                     self.outside_text_buffer.append(self.buffer[:-partial_len])
@@ -167,7 +168,7 @@ class MarkdownParser(Parser):
         idx = self._find_closing_fence_index(self.buffer)
         if idx == -1:
             # No valid closing fence found.
-            partial_len = self._longest_prefix_at_end(self.buffer, self.CLOSE_FENCE)
+            partial_len = longest_prefix_at_end(self.buffer, self.CLOSE_FENCE)
             if partial_len:
                 if len(self.buffer) > partial_len:
                     content = self.buffer[:-partial_len]
@@ -257,14 +258,3 @@ class MarkdownParser(Parser):
             self.outside_text_buffer = []
         return events
 
-    @staticmethod
-    def _longest_prefix_at_end(buf: str, full_str: str) -> int:
-        """
-        Determines if the end of `buf` is a prefix of `full_str`. This is used
-        to preserve partial code fences across chunks.
-        """
-        max_len = min(len(buf), len(full_str) - 1)
-        for length in range(max_len, 0, -1):
-            if buf.endswith(full_str[:length]):
-                return length
-        return 0

--- a/ai_agent_toolbox/parsers/utils.py
+++ b/ai_agent_toolbox/parsers/utils.py
@@ -1,0 +1,24 @@
+"""Utility helpers shared across parser implementations."""
+
+from __future__ import annotations
+
+
+def longest_prefix_at_end(buf: str, full_str: str) -> int:
+    """Return length of the longest prefix of ``full_str`` found at the end of ``buf``.
+
+    This mirrors the prefix-preservation logic used by the streaming parsers to
+    keep partial tag or fence delimiters across chunk boundaries. Only strict
+    prefixes of ``full_str`` are considered (i.e. a complete match returns 0).
+    """
+
+    if not buf or not full_str:
+        return 0
+
+    max_len = min(len(buf), max(len(full_str) - 1, 0))
+    for length in range(max_len, 0, -1):
+        if buf.endswith(full_str[:length]):
+            return length
+    return 0
+
+
+__all__ = ["longest_prefix_at_end"]

--- a/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
@@ -1,6 +1,7 @@
 import uuid
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
 from ai_agent_toolbox.parsers import Parser
+from ai_agent_toolbox.parsers.utils import longest_prefix_at_end
 
 class FlatXMLParser(Parser):
     """
@@ -209,7 +210,7 @@ class FlatXMLParser(Parser):
         close_idx = self._buffer.find(close_tag)
         if close_idx == -1:
             # Possibly partial close tag or no close tag yet
-            partial_len = self._longest_prefix_at_end(self._buffer, close_tag)
+            partial_len = longest_prefix_at_end(self._buffer, close_tag)
             if partial_len == 0:
                 # No partial prefix, so the entire buffer is content
                 if self._buffer:
@@ -332,22 +333,8 @@ class FlatXMLParser(Parser):
         longest = 0
         for t in tags:
             open_tag = f"<{t}>"
-            prefix_len = FlatXMLParser._longest_prefix_at_end(buf, open_tag)
+            prefix_len = longest_prefix_at_end(buf, open_tag)
             if prefix_len > longest:
                 longest = prefix_len
         return longest
 
-    @staticmethod
-    def _longest_prefix_at_end(buf: str, full_str: str) -> int:
-        """
-        If the end of `buf` matches a prefix of `full_str` of length L,
-        return L. Otherwise 0. E.g. if buf ends with "<thi" and full_str is "<think>",
-        return 4.
-        """
-        max_len = min(len(buf), len(full_str) - 1)
-        # We never consider a full match as "partial prefix"—that’s an actual find.
-        # So we only check up to len(full_str) - 1
-        for length in range(max_len, 0, -1):
-            if buf.endswith(full_str[:length]):
-                return length
-        return 0


### PR DESCRIPTION
## Summary
- add a shared `longest_prefix_at_end` helper for streaming parser prefix detection
- update the markdown and flat XML parsers to reuse the helper and remove the duplicated implementations

## Testing
- pytest tests/parsers

------
https://chatgpt.com/codex/tasks/task_b_68d18998354883288c35a7c725d3634f