### PR TITLE
Refactor usage prompt handling in formatters

### DIFF
--- a/ai_agent_toolbox/formatters/json/json_prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/json/json_prompt_formatter.py
@@ -50,5 +50,3 @@ class JSONPromptFormatter(PromptFormatter):
 
         return "\n".join(lines).strip()
 
-    def usage_prompt(self, toolbox) -> str:
-        return self.format_prompt(toolbox._tools)

--- a/ai_agent_toolbox/formatters/markdown/markdown_prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/markdown/markdown_prompt_formatter.py
@@ -29,8 +29,3 @@ class MarkdownPromptFormatter(PromptFormatter):
             lines.append(f"{self.fence}")
         return "\n".join(lines)
 
-    def usage_prompt(self, toolbox) -> str:
-        """
-        Generates a usage prompt from a Toolbox instance.
-        """
-        return self.format_prompt(toolbox._tools)

--- a/ai_agent_toolbox/formatters/prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/prompt_formatter.py
@@ -1,11 +1,13 @@
 from typing import Dict
 
+
 class PromptFormatter:
     """Abstract base class for prompt formatters."""
+
     def format_prompt(self, tools: Dict[str, Dict[str, str]]) -> str:
         """Formats the prompt to describe available tools."""
-        pass
+        raise NotImplementedError
 
     def usage_prompt(self, toolbox) -> str:
         """Generates a usage prompt from a Toolbox instance."""
-        pass
+        return self.format_prompt(toolbox._tools)

--- a/ai_agent_toolbox/formatters/xml/flat_xml_prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/xml/flat_xml_prompt_formatter.py
@@ -31,8 +31,3 @@ class FlatXMLPromptFormatter(PromptFormatter):
 
         return "\n".join(lines)
 
-    def usage_prompt(self, toolbox) -> str:
-        """
-        Generates a prompt explaining tool usage and argument schemas from a Toolbox.
-        """
-        return self.format_prompt(toolbox._tools)

--- a/ai_agent_toolbox/formatters/xml/xml_prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/xml/xml_prompt_formatter.py
@@ -43,9 +43,3 @@ class XMLPromptFormatter(PromptFormatter):
 
         return "\n".join(lines)
 
-    def usage_prompt(self, toolbox) -> str:
-        """
-        Generates a prompt explaining tool usage and argument schemas from a Toolbox.
-        """
-        base_prompt = self.format_prompt(toolbox._tools)
-        return base_prompt


### PR DESCRIPTION
## Summary
- implement PromptFormatter.usage_prompt to reuse format_prompt for Toolbox instances
- make PromptFormatter.format_prompt abstract via NotImplementedError and remove redundant overrides in concrete formatters

## Testing
- pytest tests/formatters

------
https://chatgpt.com/codex/tasks/task_b_68d189a1e0c08328a71f9e81f2804160