### PR TITLE
Refactor text flushing helpers in streaming parsers

### DIFF
--- a/ai_agent_toolbox/parsers/markdown/markdown_parser.py
+++ b/ai_agent_toolbox/parsers/markdown/markdown_parser.py
@@ -1,6 +1,7 @@
 import uuid
 from ai_agent_toolbox.parsers.parser import Parser
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parsers.utils import emit_text_block_events
 
 class MarkdownParser(Parser):
     """
@@ -230,32 +231,7 @@ class MarkdownParser(Parser):
         """
         If there is accumulated outside text, emit a full text block as create/append/close.
         """
-        events = []
-        if self.outside_text_buffer:
-            text = "".join(self.outside_text_buffer)
-            if text:
-                text_id = str(uuid.uuid4())
-                events.append(ParserEvent(
-                    type="text",
-                    mode="create",
-                    id=text_id,
-                    is_tool_call=False
-                ))
-                events.append(ParserEvent(
-                    type="text",
-                    mode="append",
-                    id=text_id,
-                    content=text,
-                    is_tool_call=False
-                ))
-                events.append(ParserEvent(
-                    type="text",
-                    mode="close",
-                    id=text_id,
-                    is_tool_call=False
-                ))
-            self.outside_text_buffer = []
-        return events
+        return emit_text_block_events(self.outside_text_buffer)
 
     @staticmethod
     def _longest_prefix_at_end(buf: str, full_str: str) -> int:

--- a/ai_agent_toolbox/parsers/utils.py
+++ b/ai_agent_toolbox/parsers/utils.py
@@ -1,0 +1,52 @@
+"""Utility helpers shared by parser implementations."""
+
+from __future__ import annotations
+
+import uuid
+from typing import List
+from collections.abc import MutableSequence
+
+from ai_agent_toolbox.parser_event import ParserEvent
+
+
+def emit_text_block_events(text_buffer: MutableSequence[str]) -> List[ParserEvent]:
+    """Convert buffered text into create/append/close events.
+
+    Args:
+        text_buffer: A mutable sequence accumulating pieces of text that should
+            be emitted together as a single text block.
+
+    Returns:
+        A list of ``ParserEvent`` objects representing the standard
+        create/append/close sequence for the concatenated text. If the
+        concatenated text is empty, an empty list is returned.
+
+    Side Effects:
+        The provided buffer is cleared in-place regardless of whether any
+        events were produced.
+    """
+
+    if not text_buffer:
+        return []
+
+    text = "".join(text_buffer)
+
+    # Always clear the buffer, even if the joined text is empty. This mirrors
+    # the previous behaviour in the parsers that accumulate the buffered text.
+    text_buffer.clear()
+
+    if not text:
+        return []
+
+    text_id = str(uuid.uuid4())
+    return [
+        ParserEvent(type="text", mode="create", id=text_id, is_tool_call=False),
+        ParserEvent(
+            type="text",
+            mode="append",
+            id=text_id,
+            content=text,
+            is_tool_call=False,
+        ),
+        ParserEvent(type="text", mode="close", id=text_id, is_tool_call=False),
+    ]

--- a/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
@@ -1,6 +1,7 @@
 import uuid
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
 from ai_agent_toolbox.parsers import Parser
+from ai_agent_toolbox.parsers.utils import emit_text_block_events
 
 class FlatXMLParser(Parser):
     """
@@ -284,42 +285,7 @@ class FlatXMLParser(Parser):
         """
         Closes out a block of outside text, emitting create/append/close if there's content.
         """
-        events = []
-        if not self._outside_text_buffer:
-            return events
-        full_text = "".join(self._outside_text_buffer)
-        if not full_text:
-            self._outside_text_buffer = []
-            return events
-
-        text_id = str(uuid.uuid4())
-        events.append(
-            ParserEvent(
-                type="text",
-                mode="create",
-                id=text_id,
-                is_tool_call=False
-            )
-        )
-        events.append(
-            ParserEvent(
-                type="text",
-                mode="append",
-                id=text_id,
-                content=full_text,
-                is_tool_call=False
-            )
-        )
-        events.append(
-            ParserEvent(
-                type="text",
-                mode="close",
-                id=text_id,
-                is_tool_call=False
-            )
-        )
-        self._outside_text_buffer = []
-        return events
+        return emit_text_block_events(self._outside_text_buffer)
 
     @staticmethod
     def _longest_tag_prefix_at_end(buf: str, tags) -> int:


### PR DESCRIPTION
## Summary
- add a shared `emit_text_block_events` helper to turn accumulated text buffers into event sequences
- update the Markdown and FlatXML streaming parsers to reuse the helper when flushing outside text

## Testing
- pytest tests/parsers

------
https://chatgpt.com/codex/tasks/task_b_68d18994729c83289fab41b1980aaf2f