### PR TITLE
Refactor partial prefix handling to shared util

### DIFF
--- a/ai_agent_toolbox/parsers/markdown/markdown_parser.py
+++ b/ai_agent_toolbox/parsers/markdown/markdown_parser.py
@@ -1,7 +1,7 @@
 import uuid
 from ai_agent_toolbox.parsers.parser import Parser
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
-from ai_agent_toolbox.parsers.utils import emit_text_block_events
+from ai_agent_toolbox.parsers.utils import emit_text_block_events, longest_prefix_at_end
 
 class MarkdownParser(Parser):
     """
@@ -91,7 +91,7 @@ class MarkdownParser(Parser):
         if idx == -1:
             # No complete opening fence found. Check if the end of the buffer
             # is a partial fence.
-            partial_len = self._longest_prefix_at_end(self.buffer, self.OPEN_FENCE)
+            partial_len = longest_prefix_at_end(self.buffer, self.OPEN_FENCE)
             if partial_len:
                 if len(self.buffer) > partial_len:
                     self.outside_text_buffer.append(self.buffer[:-partial_len])
@@ -161,7 +161,7 @@ class MarkdownParser(Parser):
         idx = self._find_closing_fence_index(self.buffer)
         if idx == -1:
             # No valid closing fence found.
-            partial_len = self._longest_prefix_at_end(self.buffer, self.CLOSE_FENCE)
+            partial_len = longest_prefix_at_end(self.buffer, self.CLOSE_FENCE)
             if partial_len:
                 if len(self.buffer) > partial_len:
                     content = self.buffer[:-partial_len]
@@ -225,15 +225,3 @@ class MarkdownParser(Parser):
         If there is accumulated outside text, emit a full text block as create/append/close.
         """
         return emit_text_block_events(self.outside_text_buffer)
-
-    @staticmethod
-    def _longest_prefix_at_end(buf: str, full_str: str) -> int:
-        """
-        Determines if the end of `buf` is a prefix of `full_str`. This is used
-        to preserve partial code fences across chunks.
-        """
-        max_len = min(len(buf), len(full_str) - 1)
-        for length in range(max_len, 0, -1):
-            if buf.endswith(full_str[:length]):
-                return length
-        return 0

--- a/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
@@ -1,7 +1,7 @@
 import uuid
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
 from ai_agent_toolbox.parsers import Parser
-from ai_agent_toolbox.parsers.utils import emit_text_block_events
+from ai_agent_toolbox.parsers.utils import emit_text_block_events, longest_prefix_at_end
 
 class FlatXMLParser(Parser):
     """
@@ -200,7 +200,7 @@ class FlatXMLParser(Parser):
         close_idx = self._buffer.find(close_tag)
         if close_idx == -1:
             # Possibly partial close tag or no close tag yet
-            partial_len = self._longest_prefix_at_end(self._buffer, close_tag)
+            partial_len = longest_prefix_at_end(self._buffer, close_tag)
             if partial_len == 0:
                 # No partial prefix, so the entire buffer is content
                 if self._buffer:
@@ -288,22 +288,7 @@ class FlatXMLParser(Parser):
         longest = 0
         for t in tags:
             open_tag = f"<{t}>"
-            prefix_len = FlatXMLParser._longest_prefix_at_end(buf, open_tag)
+            prefix_len = longest_prefix_at_end(buf, open_tag)
             if prefix_len > longest:
                 longest = prefix_len
         return longest
-
-    @staticmethod
-    def _longest_prefix_at_end(buf: str, full_str: str) -> int:
-        """
-        If the end of `buf` matches a prefix of `full_str` of length L,
-        return L. Otherwise 0. E.g. if buf ends with "<thi" and full_str is "<think>",
-        return 4.
-        """
-        max_len = min(len(buf), len(full_str) - 1)
-        # We never consider a full match as "partial prefix"—that’s an actual find.
-        # So we only check up to len(full_str) - 1
-        for length in range(max_len, 0, -1):
-            if buf.endswith(full_str[:length]):
-                return length
-        return 0

--- a/ai_agent_toolbox/parsers/xml/xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/xml_parser.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from .tool_parser import ToolParser, ToolParserState
 from ai_agent_toolbox.parsers import Parser
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parsers.utils import longest_prefix_at_end
 
 class ParserState:
     OUTSIDE = "outside"
@@ -99,13 +100,12 @@ class XMLParser(Parser):
     def _partial_prefix(self, text: str, pattern: str) -> str:
         """
         Check if the end of 'text' is a prefix of 'pattern'.
-        E.g. if text ends with "<us" and pattern is "<use_tool>", 
+        E.g. if text ends with "<us" and pattern is "<use_tool>",
         we return "<us" to keep it in buffer as a partial match.
         """
-        max_len = min(len(text), len(pattern) - 1)
-        for size in range(max_len, 0, -1):
-            if pattern.startswith(text[-size:]):
-                return text[-size:]
+        prefix_len = longest_prefix_at_end(text, pattern)
+        if prefix_len:
+            return text[-prefix_len:]
         return ""
 
     def _stream_outside_text(self, text: str):


### PR DESCRIPTION
## Summary
- add a reusable `longest_prefix_at_end` helper for partial fence/tag detection
- update the Markdown, flat XML, and XML parsers to rely on the shared helper

## Testing
- pytest tests/test_markdown_parser.py tests/test_flat_xml_parser.py tests/test_xml_parser.py
- pytest tests/parsers/markdown tests/parsers/xml

------
https://chatgpt.com/codex/tasks/task_b_68d19bcb60bc8328a567fe2584e2bafa