### PR TITLE
Refactor prompt formatters to share metadata helper

### DIFF
--- a/ai_agent_toolbox/formatters/markdown/markdown_prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/markdown/markdown_prompt_formatter.py
@@ -1,5 +1,9 @@
 from typing import Dict
-from ai_agent_toolbox.formatters.prompt_formatter import PromptFormatter
+
+from ai_agent_toolbox.formatters.prompt_formatter import (
+    PromptFormatter,
+    iter_tool_metadata,
+)
 
 class MarkdownPromptFormatter(PromptFormatter):
     """
@@ -11,21 +15,20 @@ class MarkdownPromptFormatter(PromptFormatter):
 
     def format_prompt(self, tools: Dict[str, Dict[str, str]]) -> str:
         lines = ["You can invoke the following tools using Markdown code fences:"]
-        for tool_name, data in tools.items():
+
+        for tool in iter_tool_metadata(tools):
             lines.append("")
-            lines.append(f"**Tool name:** {tool_name}")
-            lines.append(f"**Description:** {data.get('description', '')}")
+            lines.append(f"**Tool name:** {tool.name}")
+            lines.append(f"**Description:** {tool.description}")
             lines.append("**Arguments:**")
-            for arg_name, arg_schema in data.get("args", {}).items():
-                arg_type = arg_schema.get("type", "string")
-                arg_desc = arg_schema.get("description", "")
-                lines.append(f"- {arg_name} ({arg_type}): {arg_desc}")
+            for arg in tool.args:
+                lines.append(f"- {arg.name} ({arg.type}): {arg.description}")
             lines.append("")
             lines.append("**Example:**")
-            lines.append(f"{self.fence}{tool_name}")
+            lines.append(f"{self.fence}{tool.name}")
             # For each argument, provide a placeholder value.
-            for i, arg_name in enumerate(data.get("args", {}).keys(), start=1):
-                lines.append(f"    {arg_name}: value{i}")
+            for i, arg in enumerate(tool.args, start=1):
+                lines.append(f"    {arg.name}: value{i}")
             lines.append(f"{self.fence}")
         return "\n".join(lines)
 

--- a/ai_agent_toolbox/formatters/prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/prompt_formatter.py
@@ -1,13 +1,112 @@
-from typing import Dict
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
+
+__all__ = [
+    "ArgumentMetadata",
+    "ToolMetadata",
+    "iter_tool_metadata",
+    "PromptFormatter",
+]
+
+
+@dataclass(frozen=True)
+class ArgumentMetadata:
+    """Normalized metadata for a single tool argument."""
+
+    name: str
+    type: str
+    description: str
+    schema: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ToolMetadata:
+    """Normalized metadata for a registered tool."""
+
+    name: str
+    description: str
+    args: Tuple[ArgumentMetadata, ...]
+    content: Optional[ArgumentMetadata] = None
+
+
+def _normalize_schema(schema: Any) -> Dict[str, Any]:
+    """Return a dictionary representation of a schema definition."""
+
+    if schema is None:
+        return {}
+
+    if isinstance(schema, str):
+        normalized: Dict[str, Any] = {"type": schema}
+    elif isinstance(schema, Mapping):
+        normalized = dict(schema)
+    else:
+        normalized = {"type": str(schema)}
+
+    schema_type = normalized.get("type")
+    if schema_type is None:
+        normalized["type"] = "string"
+    elif not isinstance(schema_type, str):
+        normalized["type"] = str(schema_type)
+
+    if "description" in normalized and not isinstance(normalized["description"], str):
+        normalized["description"] = str(normalized["description"])
+
+    return normalized
+
+
+def iter_tool_metadata(tools: Mapping[str, Mapping[str, Any]]) -> Iterable[ToolMetadata]:
+    """Yield normalized metadata structures for tools from a toolbox dictionary."""
+
+    for tool_name, raw_data in tools.items():
+        data_candidate = raw_data or {}
+        if not isinstance(data_candidate, Mapping):
+            data_candidate = {}
+        data: Mapping[str, Any] = data_candidate
+        raw_description = data.get("description", "")
+        description = "" if raw_description is None else str(raw_description)
+
+        arg_entries = []
+        for arg_name, arg_schema in (data.get("args") or {}).items():
+            normalized = _normalize_schema(arg_schema)
+            arg_entries.append(
+                ArgumentMetadata(
+                    name=arg_name,
+                    type=normalized.get("type", "string"),
+                    description=normalized.get("description", ""),
+                    schema=normalized,
+                )
+            )
+        args: Tuple[ArgumentMetadata, ...] = tuple(arg_entries)
+
+        content_meta: Optional[ArgumentMetadata] = None
+        if "content" in data and data.get("content") is not None:
+            normalized = _normalize_schema(data.get("content"))
+            content_meta = ArgumentMetadata(
+                name="content",
+                type=normalized.get("type", "string"),
+                description=normalized.get("description", ""),
+                schema=normalized,
+            )
+
+        yield ToolMetadata(
+            name=tool_name,
+            description=description,
+            args=args,
+            content=content_meta,
+        )
 
 
 class PromptFormatter:
     """Abstract base class for prompt formatters."""
 
-    def format_prompt(self, tools: Dict[str, Dict[str, str]]) -> str:
+    def format_prompt(self, tools: Mapping[str, Mapping[str, Any]]) -> str:
         """Formats the prompt to describe available tools."""
+
         raise NotImplementedError
 
     def usage_prompt(self, toolbox) -> str:
-        """Generates a usage prompt from a Toolbox instance."""
+        """Generate a usage prompt from a Toolbox instance."""
+
         return self.format_prompt(toolbox._tools)

--- a/ai_agent_toolbox/formatters/xml/flat_xml_prompt_formatter.py
+++ b/ai_agent_toolbox/formatters/xml/flat_xml_prompt_formatter.py
@@ -1,5 +1,9 @@
 from typing import Dict
-from ai_agent_toolbox.formatters.prompt_formatter import PromptFormatter
+
+from ai_agent_toolbox.formatters.prompt_formatter import (
+    PromptFormatter,
+    iter_tool_metadata,
+)
 
 class FlatXMLPromptFormatter(PromptFormatter):
     """
@@ -11,23 +15,28 @@ class FlatXMLPromptFormatter(PromptFormatter):
     def format_prompt(self, tools: Dict[str, Dict[str, str]]) -> str:
         lines = [f"You can invoke the following tools using <{self.tag}>:"]
 
-        for tool_name, data in tools.items():
-            lines.extend([
-                f"Tool name: {tool_name}",
-                f"Description: {data['description']}",
-                "Argument: string",
-            ])
-            if data.get('content', {}).get('description', None):
-                lines.extend([f"Argument description: {data['content']['description']}"])
+        for tool in iter_tool_metadata(tools):
+            lines.extend(
+                [
+                    f"Tool name: {tool.name}",
+                    f"Description: {tool.description}",
+                    "Argument: string",
+                ]
+            )
+
+            if tool.content and tool.content.description:
+                lines.append(f"Argument description: {tool.content.description}")
 
             lines.append("")
 
-        lines.extend([
-            "Example:",
-            f"<{self.tag}>",
-            "arguments",
-            f"</{self.tag}>"
-        ])
+        lines.extend(
+            [
+                "Example:",
+                f"<{self.tag}>",
+                "arguments",
+                f"</{self.tag}>",
+            ]
+        )
 
         return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- add reusable metadata dataclasses and helper for normalizing toolbox tool definitions
- update JSON, Markdown, XML, and Flat XML prompt formatters to consume shared metadata structures
- keep formatter behavior verified via existing tests

## Testing
- pytest tests/formatters

------
https://chatgpt.com/codex/tasks/task_b_68d19bd283e8832885210031795d86f4