### PR TITLE
Document module layout expectations in AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Contribution Guidelines
+
+## Module layout
+- Keep modules focused and compact. If an implementation grows beyond ~250 lines (including helper functions), look for opportunities to split it into smaller pieces or extract shared helpers.
+- New classes should live in their own module. Name the module after the class using ``snake_case`` (for example, ``XMLPromptFormatter`` lives in ``xml_prompt_formatter.py``).
+- Lightweight helper functions or dataclasses that exist solely to support the primary class may stay in the same module, but avoid defining multiple top-level classes with independent responsibilities in a single file.
+
+## Package organisation
+- Production code lives under ``ai_agent_toolbox``. Tests and examples stay in their existing top-level folders.
+- Parsers belong in ``ai_agent_toolbox/parsers`` and prompt formatters in ``ai_agent_toolbox/formatters``. Each specialised format (XML, JSON, Markdown, etc.) has its own subpackage; add new formats by creating a matching folder and module pair.
+- Utility-only modules should use a ``utils.py`` suffix (for example, ``ai_agent_toolbox/parsers/utils.py``) and keep their APIs narrowly scoped.
+
+## Scoped guidelines
+Additional notes for particular subpackages are documented in nested ``AGENTS.md`` files (see ``ai_agent_toolbox/parsers`` and ``ai_agent_toolbox/formatters``).

--- a/ai_agent_toolbox/formatters/AGENTS.md
+++ b/ai_agent_toolbox/formatters/AGENTS.md
@@ -1,0 +1,5 @@
+# Formatter package guidelines
+
+- Implement each concrete prompt formatter in its own module named ``<format>_prompt_formatter.py`` under the corresponding format subpackage (for example, ``json/json_prompt_formatter.py``).
+- Keep formatter modules lean; if you find yourself adding reusable helper logic, move it into ``prompt_formatter.py`` or a dedicated utility module instead of introducing multiple formatter classes per file.
+- Update ``ai_agent_toolbox/__init__.py`` and ``ai_agent_toolbox/formatters/__init__.py`` when adding a formatter so it is importable from the package root.

--- a/ai_agent_toolbox/parsers/AGENTS.md
+++ b/ai_agent_toolbox/parsers/AGENTS.md
@@ -1,0 +1,6 @@
+# Parser package guidelines
+
+- Place each concrete parser in its own module named ``<format>_parser.py`` under a dedicated subpackage (for example, ``xml/xml_parser.py``).
+- Keep parser modules narrowly focused; if a parser grows beyond ~200 lines split shared logic into helpers under ``utils.py`` or a new private module.
+- When introducing a new parser variant, expose it via ``ai_agent_toolbox/__init__.py`` so that ``from ai_agent_toolbox import NewParser`` continues to work.
+- Reuse ``parser.py`` for abstract base classes and ensure helpers shared across parsers stay in ``utils.py`` to avoid duplication.


### PR DESCRIPTION
## Summary
- add a top-level AGENTS.md describing module size expectations and the one-class-per-file rule
- document parser-specific placement and re-export requirements
- document formatter-specific module naming and export updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d19f0a2b9c832892d8e5fb64bf3ef7