### PR TITLE
Refactor XML parser state into shared enum

### DIFF
--- a/ai_agent_toolbox/parsers/xml/__init__.py
+++ b/ai_agent_toolbox/parsers/xml/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for XML-based parsers."""
+
+from .parser_state import ParserState
+
+__all__ = ["ParserState"]

--- a/ai_agent_toolbox/parsers/xml/parser_state.py
+++ b/ai_agent_toolbox/parsers/xml/parser_state.py
@@ -1,0 +1,14 @@
+"""Parser state definitions for XML parsing."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class ParserState(str, Enum):
+    """Possible states for the :class:`XMLParser`."""
+
+    OUTSIDE = "outside"
+    INSIDE_TOOL = "inside_tool"
+
+
+__all__ = ["ParserState"]

--- a/ai_agent_toolbox/parsers/xml/xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/xml_parser.py
@@ -1,13 +1,10 @@
 from typing import List
 
 from .tool_parser import ToolParser, ToolParserState
+from .parser_state import ParserState
 from ai_agent_toolbox.parsers import Parser
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
 from ai_agent_toolbox.parsers.utils import TextEventStream
-
-class ParserState:
-    OUTSIDE = "outside"
-    INSIDE_TOOL = "inside_tool"
 
 class XMLParser(Parser):
     """


### PR DESCRIPTION
## Summary
- add a dedicated `parser_state` module that exposes a `ParserState` enum for XML parsing
- update `XMLParser` to import the shared enum and re-export it from the XML parser package

## Testing
- pytest tests/test_xml_parser.py
- pytest tests/parsers/xml/test_xml_parser.py

------
https://chatgpt.com/codex/tasks/task_b_68d19f06cf1c8328830748d99a2d5261