### PR TITLE
Refactor XML tool parser state into dedicated module

### DIFF
--- a/ai_agent_toolbox/parsers/xml/tool_parser.py
+++ b/ai_agent_toolbox/parsers/xml/tool_parser.py
@@ -2,10 +2,7 @@ import uuid
 from typing import Optional, List, Dict
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
 
-class ToolParserState:
-    WAITING_FOR_NAME = "waiting_for_name"
-    HAS_NAME = "has_name"
-    DONE = "done"
+from .tool_parser_state import ToolParserState
 
 class ToolParser:
     """

--- a/ai_agent_toolbox/parsers/xml/tool_parser_state.py
+++ b/ai_agent_toolbox/parsers/xml/tool_parser_state.py
@@ -1,0 +1,11 @@
+"""Tool parser state definitions."""
+
+from enum import Enum
+
+
+class ToolParserState(str, Enum):
+    """States for :class:`ToolParser`."""
+
+    WAITING_FOR_NAME = "waiting_for_name"
+    HAS_NAME = "has_name"
+    DONE = "done"

--- a/ai_agent_toolbox/parsers/xml/xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/xml_parser.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from .tool_parser import ToolParser, ToolParserState
+from .tool_parser import ToolParser
+from .tool_parser_state import ToolParserState
 from ai_agent_toolbox.parsers import Parser
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
 from ai_agent_toolbox.parsers.utils import TextEventStream


### PR DESCRIPTION
## Summary
- extract `ToolParserState` into a new `tool_parser_state` module and implement it as a `str` `Enum`
- update the XML tool parser and XML parser to import the refactored state definition

## Testing
- pytest tests/parsers

------
https://chatgpt.com/codex/tasks/task_b_68d19f030f8483288fdce1ec3c7fc682