### PR TITLE
Extract ToolConflictError to exceptions module

### DIFF
--- a/ai_agent_toolbox/exceptions.py
+++ b/ai_agent_toolbox/exceptions.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for the ai_agent_toolbox package."""
+
+class ToolConflictError(Exception):
+    """Raised when trying to register a tool name that already exists."""
+
+    pass
+
+
+__all__ = ["ToolConflictError"]

--- a/ai_agent_toolbox/toolbox.py
+++ b/ai_agent_toolbox/toolbox.py
@@ -2,12 +2,9 @@ import inspect
 import json
 from typing import Any, Callable, Dict, Optional
 
+from .exceptions import ToolConflictError
 from .parser_event import ParserEvent, ToolUse
 from .tool_response import ToolResponse
-
-class ToolConflictError(Exception):
-    """Raised when trying to register a tool name that already exists"""
-    pass
 
 class Toolbox:
     def __init__(self):

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -3,7 +3,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from ai_agent_toolbox.toolbox import Toolbox, ToolConflictError
+from ai_agent_toolbox.exceptions import ToolConflictError
+from ai_agent_toolbox.toolbox import Toolbox
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
 
 def test_use_tool_happy_path():


### PR DESCRIPTION
## Summary
- add an exceptions module that defines and exports ToolConflictError
- update the toolbox implementation to import the error from the shared module
- adjust toolbox tests to reference the new exception location

## Testing
- pytest (fails: import mismatch between duplicate test module names)
- pytest tests/test_toolbox.py


------
https://chatgpt.com/codex/tasks/task_b_68d19ef95a0c832894ddc4985fa55f6f