### PR TITLE
Refactor ToolUse into separate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ import json
 from dataclasses import dataclass
 
 from ai_agent_toolbox import Toolbox
-from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parser_event import ParserEvent
+from ai_agent_toolbox.tool_use import ToolUse
 
 
 @dataclass

--- a/ai_agent_toolbox/__init__.py
+++ b/ai_agent_toolbox/__init__.py
@@ -8,11 +8,13 @@ from .formatters.xml.flat_xml_prompt_formatter import FlatXMLPromptFormatter
 from .formatters.markdown.markdown_prompt_formatter import MarkdownPromptFormatter
 from .formatters.json.json_prompt_formatter import JSONPromptFormatter
 from .parser_event import ParserEvent
+from .tool_use import ToolUse
 from .tool_response import ToolResponse
 
 __all__ = [
     "Toolbox",
     "ParserEvent",
+    "ToolUse",
     "ToolResponse",
     "XMLParser",
     "FlatXMLParser",

--- a/ai_agent_toolbox/parser_event.py
+++ b/ai_agent_toolbox/parser_event.py
@@ -1,10 +1,7 @@
-from dataclasses import dataclass, field
-from typing import Optional, Any, Dict
+from dataclasses import dataclass
+from typing import Optional
 
-@dataclass
-class ToolUse:
-    name: str
-    args: Dict[str, Any] = field(default_factory=dict)
+from .tool_use import ToolUse
 
 @dataclass
 class ParserEvent:

--- a/ai_agent_toolbox/parsers/json/json_parser.py
+++ b/ai_agent_toolbox/parsers/json/json_parser.py
@@ -3,7 +3,8 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
-from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parser_event import ParserEvent
+from ai_agent_toolbox.tool_use import ToolUse
 from ai_agent_toolbox.parsers.utils import TextEventStream
 from ai_agent_toolbox.parsers.parser import Parser
 

--- a/ai_agent_toolbox/parsers/markdown/markdown_parser.py
+++ b/ai_agent_toolbox/parsers/markdown/markdown_parser.py
@@ -1,6 +1,7 @@
 import uuid
 from ai_agent_toolbox.parsers.parser import Parser
-from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parser_event import ParserEvent
+from ai_agent_toolbox.tool_use import ToolUse
 from ai_agent_toolbox.parsers.utils import emit_text_block_events
 
 class MarkdownParser(Parser):

--- a/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/flat_xml_parser.py
@@ -1,5 +1,6 @@
 import uuid
-from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parser_event import ParserEvent
+from ai_agent_toolbox.tool_use import ToolUse
 from ai_agent_toolbox.parsers import Parser
 from ai_agent_toolbox.parsers.utils import emit_text_block_events
 

--- a/ai_agent_toolbox/parsers/xml/tool_parser.py
+++ b/ai_agent_toolbox/parsers/xml/tool_parser.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import Optional, List, Dict
-from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parser_event import ParserEvent
+from ai_agent_toolbox.tool_use import ToolUse
 
 class ToolParserState:
     WAITING_FOR_NAME = "waiting_for_name"

--- a/ai_agent_toolbox/parsers/xml/xml_parser.py
+++ b/ai_agent_toolbox/parsers/xml/xml_parser.py
@@ -2,7 +2,8 @@ from typing import List
 
 from .tool_parser import ToolParser, ToolParserState
 from ai_agent_toolbox.parsers import Parser
-from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parser_event import ParserEvent
+from ai_agent_toolbox.tool_use import ToolUse
 from ai_agent_toolbox.parsers.utils import TextEventStream
 
 class ParserState:

--- a/ai_agent_toolbox/tool_response.py
+++ b/ai_agent_toolbox/tool_response.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Optional
-from .parser_event import ToolUse
+from .tool_use import ToolUse
 
 @dataclass
 class ToolResponse:

--- a/ai_agent_toolbox/tool_use.py
+++ b/ai_agent_toolbox/tool_use.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+@dataclass
+class ToolUse:
+    name: str
+    args: Dict[str, Any] = field(default_factory=dict)

--- a/ai_agent_toolbox/toolbox.py
+++ b/ai_agent_toolbox/toolbox.py
@@ -2,7 +2,8 @@ import inspect
 import json
 from typing import Any, Callable, Dict, Optional
 
-from .parser_event import ParserEvent, ToolUse
+from .parser_event import ParserEvent
+from .tool_use import ToolUse
 from .tool_response import ToolResponse
 
 class ToolConflictError(Exception):

--- a/docs/api-reference/toolbox.md
+++ b/docs/api-reference/toolbox.md
@@ -70,7 +70,8 @@ toolbox.add_tool(
 ```python
 import json
 from ai_agent_toolbox import Toolbox
-from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parser_event import ParserEvent
+from ai_agent_toolbox.tool_use import ToolUse
 
 def summarize_tasks(tasks, metadata, priority, limit):
     return {

--- a/tests/parsers/markdown/test_markdown_parser.py
+++ b/tests/parsers/markdown/test_markdown_parser.py
@@ -1,6 +1,7 @@
 import pytest
 from ai_agent_toolbox.parsers.markdown.markdown_parser import MarkdownParser
-from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parser_event import ParserEvent
+from ai_agent_toolbox.tool_use import ToolUse
 
 # --- Assertion Helpers ---
 

--- a/tests/test_toolbox.py
+++ b/tests/test_toolbox.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock
 import pytest
 
 from ai_agent_toolbox.toolbox import Toolbox, ToolConflictError
-from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
+from ai_agent_toolbox.parser_event import ParserEvent
+from ai_agent_toolbox.tool_use import ToolUse
 
 def test_use_tool_happy_path():
     """


### PR DESCRIPTION
## Summary
- extract the `ToolUse` dataclass into a dedicated `ai_agent_toolbox.tool_use` module and re-export it via the package init
- update parser events, toolbox utilities, tests, and docs to import `ToolUse` from the new module

## Testing
- pytest --import-mode=importlib

------
https://chatgpt.com/codex/tasks/task_b_68d19ef927588328b4b16410ac66f1c9