### PR TITLE
refactor: extract tool call state dataclass

### DIFF
--- a/ai_agent_toolbox/parsers/json/json_parser.py
+++ b/ai_agent_toolbox/parsers/json/json_parser.py
@@ -1,23 +1,12 @@
 import json
 import uuid
-from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from ai_agent_toolbox.parser_event import ParserEvent, ToolUse
 from ai_agent_toolbox.parsers.utils import TextEventStream
 from ai_agent_toolbox.parsers.parser import Parser
 
-
-@dataclass
-class ToolCallState:
-    """Tracks state for an in-flight JSON tool call."""
-
-    internal_id: str
-    name: Optional[str] = None
-    argument_buffer: str = ""
-    created: bool = False
-    closed: bool = False
-    keys: List[Tuple[str, Any]] = field(default_factory=list)
+from .tool_call_state import ToolCallState
 
 
 class JSONParser(Parser):

--- a/ai_agent_toolbox/parsers/json/tool_call_state.py
+++ b/ai_agent_toolbox/parsers/json/tool_call_state.py
@@ -1,0 +1,16 @@
+"""Tool call state tracking for JSON parsers."""
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
+
+
+@dataclass
+class ToolCallState:
+    """Tracks state for an in-flight JSON tool call."""
+
+    internal_id: str
+    name: Optional[str] = None
+    argument_buffer: str = ""
+    created: bool = False
+    closed: bool = False
+    keys: List[Tuple[str, Any]] = field(default_factory=list)


### PR DESCRIPTION
## Summary
- add a dedicated module for the `ToolCallState` dataclass used by the JSON parser
- update the JSON parser to import the shared tool call state implementation

## Testing
- pytest tests/parsers/json

------
https://chatgpt.com/codex/tasks/task_b_68d19eff25548328b1f7d5b3ade724d7