### PR TITLE
Fix packaging metadata for PyPI uploads

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,6 +3,6 @@ current_version = 0.2.0
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ai-agent-toolbox"
+version = "0.2.0"
+description = "An easy to use framework for adding tool use to AI agents."
+readme = "README.md"
+requires-python = ">=3.7"
+license = { text = "MIT" }
+authors = [
+    { name = "255labs.xyz", email = "martyn@255bits.com" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[project.urls]
+Homepage = "https://github.com/255BITS/ai-agent-toolbox"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["ai_agent_toolbox*"]

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,5 @@
 #!/usr/bin/env python
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name="ai_agent_toolbox",
-    version='0.2.0',
-    packages=find_packages(),
-    include_package_data=True,
-    install_requires=[],
-    extras_require={
-        'dev': ['pytest']
-    },
-    python_requires=">=3.7",
-    license="MIT",
-    description="An easy to use framework for adding tool use to AI agents.",
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    author="255labs.xyz",
-    author_email="martyn@255bits.com",
-    url="https://github.com/255BITS/ai-agent-toolbox",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` with canonical project metadata and setuptools build backend configuration
- slim `setup.py` to delegate to setuptools so metadata is sourced from `pyproject.toml`
- update the bumpversion configuration to track the version stored in `pyproject.toml`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d437c3b5c483289a2525e2b8871c82